### PR TITLE
Fixed the Gtk-WARNINGs on GNOME 3.26.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Run
 
 from the same directory as this README resides in, or
 
-    sudo rm -rf /usr/share/themes/{Arc,Arc-Darker,Arc-Dark}
+    sudo rm -rf /usr/share/themes/{Arc-Red,Arc-Red-Darker,Arc-Red-Dark}
 
 ### Todo
 

--- a/common/gnome-shell/3.18/gnome-shell-dark.css
+++ b/common/gnome-shell/3.18/gnome-shell-dark.css
@@ -124,7 +124,7 @@ StScrollBar {
   -slider-active-background-color: #cc575d;
   -slider-active-border-color: transparent;
   -slider-border-width: 0;
-  -slider-handle-radius: 4px;
+  -slider-handle-radius: 0px;
   height: 18px;
   border: 0 solid transparent;
   border-right-width: 1px;
@@ -275,13 +275,13 @@ StScrollBar {
     color: #e3e7ed;
     font-size: 8pt; }
   .end-session-dialog .modal-dialog-linked-button:last-child {
-    color: #ffffff;
+    color: white;
     background-color: #F04A50; }
     .end-session-dialog .modal-dialog-linked-button:last-child:hover {
-      color: #ffffff;
+      color: white;
       background-color: #f47479; }
     .end-session-dialog .modal-dialog-linked-button:last-child:active {
-      color: #ffffff;
+      color: white;
       background-color: #ee3239; }
 
 .shell-mount-operation-icon {
@@ -414,6 +414,23 @@ StScrollBar {
 .audio-selection-device-icon {
   icon-size: 64px; }
 
+.access-dialog {
+  spacing: 30px; }
+  .access-dialog-main-layout {
+    padding: 12px 20px 0;
+    spacing: 12px; }
+  .access-dialog-content {
+    max-width: 28em;
+    spacing: 20px; }
+  .access-dialog-icon {
+    min-width: 48px;
+    icon-size: 48px; }
+  .access-dialog-title {
+    font-weight: bold; }
+  .access-dialog-subtitle {
+    color: #D3DAE3;
+    font-weight: bold; }
+
 .geolocation-dialog {
   spacing: 30px; }
   .geolocation-dialog-main-layout {
@@ -512,7 +529,7 @@ StScrollBar {
   margin: 32px;
   min-width: 64px;
   min-height: 64px;
-  color: #ffffff;
+  color: white;
   background: none;
   border: none;
   border-radius: 5px;
@@ -525,6 +542,9 @@ StScrollBar {
     background-color: rgba(0, 0, 0, 0.5);
     border-radius: 2px;
     color: #cc575d; }
+  .osd-window .level-bar {
+    background-color: #cc575d;
+    border-radius: 2px; }
 
 .resize-popup {
   color: #BAC3CF;
@@ -548,7 +568,8 @@ StScrollBar {
     spacing: 8px; }
   .switcher-list .item-box {
     padding: 8px;
-    border-radius: 2px; }
+    border-radius: 2px;
+    border: 1px solid transparent; }
     .switcher-list .item-box:outlined {
       padding: 8px;
       border: 1px solid #cc575d; }
@@ -569,12 +590,15 @@ StScrollBar {
   border-color: transparent;
   color: #BAC3CF; }
   .switcher-arrow:highlighted {
-    color: #ffffff; }
+    color: white; }
 
 .input-source-switcher-symbol {
   font-size: 34pt;
   width: 96px;
   height: 96px; }
+
+.cycler-highlight {
+  border: 5px solid #cc575d; }
 
 .workspace-switcher {
   background: transparent;
@@ -651,7 +675,7 @@ StScrollBar {
     -natural-hpadding: 10px;
     -minimum-hpadding: 6px;
     font-weight: bold;
-    color: #ffffff;
+    color: white;
     transition-duration: 100ms;
     border-bottom-width: 1px;
     border-color: transparent; }
@@ -661,7 +685,7 @@ StScrollBar {
       margin-left: 0px;
       margin-right: 0px; }
     #panel .panel-button:hover {
-      color: #ffffff;
+      color: white;
       background-color: rgba(0, 0, 0, 0.17);
       border-bottom-width: 1px;
       border-color: transparent; }
@@ -773,17 +797,20 @@ StScrollBar {
 .datemenu-today-button,
 .datemenu-displays-box,
 .message-list-sections {
-  margin: 0 1.5em; }
+  margin: 0 0.4em; }
 
 .datemenu-calendar-column {
-  spacing: 0.5em; }
+  spacing: 0.5em;
+  border: none; }
 
 .datemenu-displays-section {
   padding-bottom: 3em; }
 
 .datemenu-today-button,
 .world-clocks-button,
-.message-list-section-title {
+.weather-button,
+.message-list-section-title,
+.events-section-title {
   border-radius: 3px;
   padding: .4em; }
 
@@ -795,14 +822,20 @@ StScrollBar {
 
 .datemenu-today-button,
 .world-clocks-button,
-.message-list-section-title {
+.weather-button,
+.message-list-section-title,
+.events-section-title {
   padding: 7px 10px 7px 10px;
   border: 1px solid rgba(64, 69, 82, 0); }
   .datemenu-today-button:hover, .datemenu-today-button:focus,
   .world-clocks-button:hover,
   .world-clocks-button:focus,
+  .weather-button:hover,
+  .weather-button:focus,
   .message-list-section-title:hover,
-  .message-list-section-title:focus {
+  .message-list-section-title:focus,
+  .events-section-title:hover,
+  .events-section-title:focus {
     text-shadow: 0 1px rgba(64, 69, 82, 0);
     color: #D3DAE3;
     background-color: #505666;
@@ -810,7 +843,9 @@ StScrollBar {
     box-shadow: inset 0 1px rgba(80, 86, 102, 0.05); }
   .datemenu-today-button:active,
   .world-clocks-button:active,
-  .message-list-section-title:active {
+  .weather-button:active,
+  .message-list-section-title:active,
+  .events-section-title:active {
     text-shadow: 0 1px rgba(64, 69, 82, 0);
     color: #ffffff;
     background-color: #cc575d;
@@ -821,15 +856,21 @@ StScrollBar {
   font-size: 1.5em; }
 
 .world-clocks-header,
-.message-list-section-title {
+.weather-header,
+.message-list-section-title,
+.events-section-title {
   color: rgba(211, 218, 227, 0.4);
   font-weight: bold; }
 
-.world-clocks-button:active .world-clocks-header {
+.world-clocks-button:active .world-clocks-header,
+.weather-button:active .weather-header {
   color: #ffffff; }
 
 .world-clocks-grid {
   spacing-rows: 0.4em; }
+
+.weather-box {
+  spacing: 0.4em; }
 
 .calendar-month-label {
   color: #D3DAE3;
@@ -880,7 +921,7 @@ StScrollBar {
   border-radius: 12.5px; }
   .calendar-day-base:hover, .calendar-day-base:focus {
     background-color: rgba(0, 0, 0, 0.1); }
-  .calendar-day-base:active {
+  .calendar-day-base:active, .calendar-day-base:selected {
     color: #D3DAE3;
     background-color: rgba(0, 0, 0, 0.15);
     border-width: 0; }
@@ -905,6 +946,7 @@ StScrollBar {
 
 .calendar-today,
 .calendar-today:active,
+.calendar-today:selected,
 .calendar-today:focus,
 .calendar-today:hover {
   font-weight: bold;
@@ -913,8 +955,8 @@ StScrollBar {
   border-width: 0; }
 
 .calendar-day-with-events {
-  color: #cc575d;
-  font-weight: bold; }
+  font-weight: bold;
+  background-image: url("common-assets/misc/calendar-today.svg"); }
 
 .calendar-today.calendar-day-with-events {
   color: #ffffff; }
@@ -947,6 +989,9 @@ StScrollBar {
     height: 0; }
   .message-list-placeholder StLabel {
     color: rgba(211, 218, 227, 0.45); }
+  .message-list-clear-button.button {
+    margin: 1.5em 1.5em 0;
+    padding: 4px 12px; }
   .message-list-section-close > StIcon {
     icon-size: 18px;
     border-radius: 0px;
@@ -977,34 +1022,48 @@ StScrollBar {
     .message-icon-bin:rtl {
       padding: 8px 8px 8px 0px; }
     .message-icon-bin > StIcon {
-      icon-size: 32px; }
-  .message-secondary-bin {
-    color: rgba(211, 218, 227, 0.4); }
-    .message-secondary-bin:ltr {
+      color: inherit; }
+  .message-secondary-bin,
+  .message-secondary-bin > .event-time {
+    color: rgba(211, 218, 227, 0.6);
+    font-size: 0.9em; }
+    .message-secondary-bin:ltr,
+    .message-secondary-bin > .event-time:ltr {
       padding-left: 8px; }
-    .message-secondary-bin:rtl {
+    .message-secondary-bin:rtl,
+    .message-secondary-bin > .event-time:rtl {
       padding-right: 8px; }
+  .message:active .message-secondary-bin,
+  .message:active .message-secondary-bin > .event-time {
+    color: rgba(255, 255, 255, 0.6); }
   .message-secondary-bin > StIcon {
     icon-size: 16px; }
   .message-title {
+    color: inherit;
     font-weight: bold;
     font-size: 1em;
     padding: 2px 0 2px 0; }
   .message-content {
+    color: inherit;
     padding: 8px;
     font-size: 1em; }
 
 .message-media-control {
   padding: 6px;
-  color: rgba(211, 218, 227, 0.45); }
+  color: #D3DAE3; }
   .message-media-control:last-child:ltr {
     padding-right: 18px; }
   .message-media-control:last-child:rtl {
     padding-left: 18px; }
   .message-media-control:hover {
-    color: #D3DAE3; }
+    color: rgba(211, 218, 227, 0.7); }
   .message-media-control:active {
     color: #cc575d; }
+  .message-media-control:insensitive {
+    color: rgba(211, 218, 227, 0.45); }
+
+.message:active .message-media-control {
+  color: #ffffff; }
 
 .media-message-cover-icon {
   icon-size: 32px; }
@@ -1172,7 +1231,7 @@ StScrollBar {
 
 .list-search-result-title {
   font-size: 1.5em;
-  color: #ffffff; }
+  color: white; }
 
 .list-search-result-description {
   color: #cccccc; }
@@ -1190,16 +1249,14 @@ StScrollBar {
   color: #BAC3CF;
   background-color: rgba(53, 57, 69, 0.95);
   border-color: rgba(0, 0, 0, 0.4);
-  padding: 6px 1px 6px 0px;
+  padding: 4px 0;
   border-radius: 0 3px 3px 0; }
   #dash:rtl {
     border-radius: 3px 0 0 3px; }
   .right #dash, #dash:rtl {
-    padding: 6px 0px 6px 1px; }
-  .bottom #dash {
-    padding: 1px 6px 0px 6px; }
-  .top #dash {
-    padding: 0px 6px 1px 6px; }
+    padding: 4px 0; }
+  .top #dash, .bottom #dash {
+    padding: 0; }
   #dash .placeholder {
     background-image: url("common-assets/dash/dash-placeholder.svg");
     background-size: contain;
@@ -1208,31 +1265,22 @@ StScrollBar {
     width: 24px;
     height: 24px; }
 
-.dash-item-container > StWidget {
-  padding: 0px 4px 0px 5px; }
-  .right .dash-item-container > StWidget, .dash-item-container > StWidget:rtl {
-    padding: 0px 5px 0px 4px; }
-  .bottom .dash-item-container > StWidget {
-    padding: 4px 0px 5px 0px; }
-  .top .dash-item-container > StWidget {
-    padding: 5px 0px 4px 0px; }
+.dash-item-container > StWidget, .dash-item-container > StWidget:rtl, .right .dash-item-container > StWidget {
+  padding: 4px 8px; }
+
+.top .dash-item-container > StWidget, .bottom .dash-item-container > StWidget {
+  padding: 6px; }
 
 .dash-label {
   border-radius: 3px;
   padding: 4px 12px;
-  color: #ffffff;
+  color: white;
   background-color: rgba(0, 0, 0, 0.7);
   text-align: center;
   -x-offset: 3px; }
   .bottom .dash-label, .top .dash-label {
     -y-offset: 3px;
     -x-offset: 0; }
-
-#dash .app-well-app .overview-icon,
-.right #dash .app-well-app .overview-icon,
-.bottom #dash .app-well-app .overview-icon,
-.top #dash .app-well-app .overview-icon {
-  padding: 10px; }
 
 #dash .app-well-app:hover .overview-icon,
 .right #dash .app-well-app:hover .overview-icon,
@@ -1250,7 +1298,7 @@ StScrollBar {
 #dash .app-well-app-running-dot {
   width: 11px;
   height: 2px;
-  margin-bottom: 6px;
+  margin-bottom: 2px;
   background-color: #cc575d; }
 
 #dashtodockContainer .app-well-app-running-dot {
@@ -1271,7 +1319,6 @@ StScrollBar {
   background-image: url("common-assets/dash/running4.svg"); }
 
 .show-apps .overview-icon {
-  padding: 11px;
   background-color: rgba(0, 0, 0, 0.5);
   border-radius: 2px;
   border: 0px solid; }
@@ -1367,7 +1414,7 @@ StScrollBar {
 .list-search-result, .app-well-app .overview-icon,
 .app-well-app.app-folder .overview-icon,
 .grid-search-result .overview-icon {
-  color: #ffffff;
+  color: white;
   border-radius: 2px;
   padding: 6px;
   border: 1px solid transparent;
@@ -1382,6 +1429,7 @@ StScrollBar {
   background-color: rgba(60, 64, 78, 0.95); }
 
 .app-well-app.app-folder:active > .overview-icon, .app-well-app.app-folder:checked > .overview-icon {
+  color: #ffffff;
   background-color: #cc575d;
   box-shadow: none; }
 
@@ -1940,7 +1988,7 @@ StScrollBar {
     padding-left: .3em;
     padding-right: .3em; }
     #LookingGlassDialog .notebook-tab:hover {
-      color: #ffffff;
+      color: white;
       text-shadow: black 0px 2px 2px; }
     #LookingGlassDialog .notebook-tab:selected {
       border-bottom-width: 0px;

--- a/common/gnome-shell/3.18/gnome-shell.css
+++ b/common/gnome-shell/3.18/gnome-shell.css
@@ -124,7 +124,7 @@ StScrollBar {
   -slider-active-background-color: #cc575d;
   -slider-active-border-color: transparent;
   -slider-border-width: 0;
-  -slider-handle-radius: 4px;
+  -slider-handle-radius: 0px;
   height: 18px;
   border: 0 solid transparent;
   border-right-width: 1px;
@@ -275,13 +275,13 @@ StScrollBar {
     color: #686d7a;
     font-size: 8pt; }
   .end-session-dialog .modal-dialog-linked-button:last-child {
-    color: #ffffff;
+    color: white;
     background-color: #F04A50; }
     .end-session-dialog .modal-dialog-linked-button:last-child:hover {
-      color: #ffffff;
+      color: white;
       background-color: #f47479; }
     .end-session-dialog .modal-dialog-linked-button:last-child:active {
-      color: #ffffff;
+      color: white;
       background-color: #ee3239; }
 
 .shell-mount-operation-icon {
@@ -414,6 +414,23 @@ StScrollBar {
 .audio-selection-device-icon {
   icon-size: 64px; }
 
+.access-dialog {
+  spacing: 30px; }
+  .access-dialog-main-layout {
+    padding: 12px 20px 0;
+    spacing: 12px; }
+  .access-dialog-content {
+    max-width: 28em;
+    spacing: 20px; }
+  .access-dialog-icon {
+    min-width: 48px;
+    icon-size: 48px; }
+  .access-dialog-title {
+    font-weight: bold; }
+  .access-dialog-subtitle {
+    color: #5c616c;
+    font-weight: bold; }
+
 .geolocation-dialog {
   spacing: 30px; }
   .geolocation-dialog-main-layout {
@@ -512,7 +529,7 @@ StScrollBar {
   margin: 32px;
   min-width: 64px;
   min-height: 64px;
-  color: #ffffff;
+  color: white;
   background: none;
   border: none;
   border-radius: 5px;
@@ -525,6 +542,9 @@ StScrollBar {
     background-color: rgba(0, 0, 0, 0.5);
     border-radius: 2px;
     color: #cc575d; }
+  .osd-window .level-bar {
+    background-color: #cc575d;
+    border-radius: 2px; }
 
 .resize-popup {
   color: #BAC3CF;
@@ -548,7 +568,8 @@ StScrollBar {
     spacing: 8px; }
   .switcher-list .item-box {
     padding: 8px;
-    border-radius: 2px; }
+    border-radius: 2px;
+    border: 1px solid transparent; }
     .switcher-list .item-box:outlined {
       padding: 8px;
       border: 1px solid #cc575d; }
@@ -569,12 +590,15 @@ StScrollBar {
   border-color: transparent;
   color: #BAC3CF; }
   .switcher-arrow:highlighted {
-    color: #ffffff; }
+    color: white; }
 
 .input-source-switcher-symbol {
   font-size: 34pt;
   width: 96px;
   height: 96px; }
+
+.cycler-highlight {
+  border: 5px solid #cc575d; }
 
 .workspace-switcher {
   background: transparent;
@@ -651,7 +675,7 @@ StScrollBar {
     -natural-hpadding: 10px;
     -minimum-hpadding: 6px;
     font-weight: bold;
-    color: #ffffff;
+    color: white;
     transition-duration: 100ms;
     border-bottom-width: 1px;
     border-color: transparent; }
@@ -661,7 +685,7 @@ StScrollBar {
       margin-left: 0px;
       margin-right: 0px; }
     #panel .panel-button:hover {
-      color: #ffffff;
+      color: white;
       background-color: rgba(0, 0, 0, 0.17);
       border-bottom-width: 1px;
       border-color: transparent; }
@@ -773,17 +797,20 @@ StScrollBar {
 .datemenu-today-button,
 .datemenu-displays-box,
 .message-list-sections {
-  margin: 0 1.5em; }
+  margin: 0 0.4em; }
 
 .datemenu-calendar-column {
-  spacing: 0.5em; }
+  spacing: 0.5em;
+  border: none; }
 
 .datemenu-displays-section {
   padding-bottom: 3em; }
 
 .datemenu-today-button,
 .world-clocks-button,
-.message-list-section-title {
+.weather-button,
+.message-list-section-title,
+.events-section-title {
   border-radius: 3px;
   padding: .4em; }
 
@@ -795,14 +822,20 @@ StScrollBar {
 
 .datemenu-today-button,
 .world-clocks-button,
-.message-list-section-title {
+.weather-button,
+.message-list-section-title,
+.events-section-title {
   padding: 7px 10px 7px 10px;
   border: 1px solid rgba(255, 255, 255, 0); }
   .datemenu-today-button:hover, .datemenu-today-button:focus,
   .world-clocks-button:hover,
   .world-clocks-button:focus,
+  .weather-button:hover,
+  .weather-button:focus,
   .message-list-section-title:hover,
-  .message-list-section-title:focus {
+  .message-list-section-title:focus,
+  .events-section-title:hover,
+  .events-section-title:focus {
     text-shadow: 0 1px rgba(255, 255, 255, 0);
     color: #5c616c;
     background-color: white;
@@ -810,7 +843,9 @@ StScrollBar {
     box-shadow: inset 0 1px rgba(255, 255, 255, 0.05); }
   .datemenu-today-button:active,
   .world-clocks-button:active,
-  .message-list-section-title:active {
+  .weather-button:active,
+  .message-list-section-title:active,
+  .events-section-title:active {
     text-shadow: 0 1px rgba(255, 255, 255, 0);
     color: #ffffff;
     background-color: #cc575d;
@@ -821,15 +856,21 @@ StScrollBar {
   font-size: 1.5em; }
 
 .world-clocks-header,
-.message-list-section-title {
+.weather-header,
+.message-list-section-title,
+.events-section-title {
   color: rgba(92, 97, 108, 0.4);
   font-weight: bold; }
 
-.world-clocks-button:active .world-clocks-header {
+.world-clocks-button:active .world-clocks-header,
+.weather-button:active .weather-header {
   color: #ffffff; }
 
 .world-clocks-grid {
   spacing-rows: 0.4em; }
+
+.weather-box {
+  spacing: 0.4em; }
 
 .calendar-month-label {
   color: #5c616c;
@@ -880,7 +921,7 @@ StScrollBar {
   border-radius: 12.5px; }
   .calendar-day-base:hover, .calendar-day-base:focus {
     background-color: rgba(0, 0, 0, 0.1); }
-  .calendar-day-base:active {
+  .calendar-day-base:active, .calendar-day-base:selected {
     color: #5c616c;
     background-color: rgba(0, 0, 0, 0.15);
     border-width: 0; }
@@ -905,6 +946,7 @@ StScrollBar {
 
 .calendar-today,
 .calendar-today:active,
+.calendar-today:selected,
 .calendar-today:focus,
 .calendar-today:hover {
   font-weight: bold;
@@ -913,8 +955,8 @@ StScrollBar {
   border-width: 0; }
 
 .calendar-day-with-events {
-  color: #cc575d;
-  font-weight: bold; }
+  font-weight: bold;
+  background-image: url("common-assets/misc/calendar-today.svg"); }
 
 .calendar-today.calendar-day-with-events {
   color: #ffffff; }
@@ -947,6 +989,9 @@ StScrollBar {
     height: 0; }
   .message-list-placeholder StLabel {
     color: rgba(92, 97, 108, 0.55); }
+  .message-list-clear-button.button {
+    margin: 1.5em 1.5em 0;
+    padding: 4px 12px; }
   .message-list-section-close > StIcon {
     icon-size: 18px;
     border-radius: 0px;
@@ -977,34 +1022,48 @@ StScrollBar {
     .message-icon-bin:rtl {
       padding: 8px 8px 8px 0px; }
     .message-icon-bin > StIcon {
-      icon-size: 32px; }
-  .message-secondary-bin {
-    color: rgba(92, 97, 108, 0.4); }
-    .message-secondary-bin:ltr {
+      color: inherit; }
+  .message-secondary-bin,
+  .message-secondary-bin > .event-time {
+    color: rgba(92, 97, 108, 0.6);
+    font-size: 0.9em; }
+    .message-secondary-bin:ltr,
+    .message-secondary-bin > .event-time:ltr {
       padding-left: 8px; }
-    .message-secondary-bin:rtl {
+    .message-secondary-bin:rtl,
+    .message-secondary-bin > .event-time:rtl {
       padding-right: 8px; }
+  .message:active .message-secondary-bin,
+  .message:active .message-secondary-bin > .event-time {
+    color: rgba(255, 255, 255, 0.6); }
   .message-secondary-bin > StIcon {
     icon-size: 16px; }
   .message-title {
+    color: inherit;
     font-weight: bold;
     font-size: 1em;
     padding: 2px 0 2px 0; }
   .message-content {
+    color: inherit;
     padding: 8px;
     font-size: 1em; }
 
 .message-media-control {
   padding: 6px;
-  color: rgba(92, 97, 108, 0.55); }
+  color: #5c616c; }
   .message-media-control:last-child:ltr {
     padding-right: 18px; }
   .message-media-control:last-child:rtl {
     padding-left: 18px; }
   .message-media-control:hover {
-    color: #5c616c; }
+    color: rgba(92, 97, 108, 0.7); }
   .message-media-control:active {
     color: #cc575d; }
+  .message-media-control:insensitive {
+    color: rgba(92, 97, 108, 0.55); }
+
+.message:active .message-media-control {
+  color: #ffffff; }
 
 .media-message-cover-icon {
   icon-size: 32px; }
@@ -1172,7 +1231,7 @@ StScrollBar {
 
 .list-search-result-title {
   font-size: 1.5em;
-  color: #ffffff; }
+  color: white; }
 
 .list-search-result-description {
   color: #cccccc; }
@@ -1190,16 +1249,14 @@ StScrollBar {
   color: #BAC3CF;
   background-color: rgba(53, 57, 69, 0.95);
   border-color: rgba(0, 0, 0, 0.4);
-  padding: 6px 1px 6px 0px;
+  padding: 4px 0;
   border-radius: 0 3px 3px 0; }
   #dash:rtl {
     border-radius: 3px 0 0 3px; }
   .right #dash, #dash:rtl {
-    padding: 6px 0px 6px 1px; }
-  .bottom #dash {
-    padding: 1px 6px 0px 6px; }
-  .top #dash {
-    padding: 0px 6px 1px 6px; }
+    padding: 4px 0; }
+  .top #dash, .bottom #dash {
+    padding: 0; }
   #dash .placeholder {
     background-image: url("common-assets/dash/dash-placeholder.svg");
     background-size: contain;
@@ -1208,31 +1265,22 @@ StScrollBar {
     width: 24px;
     height: 24px; }
 
-.dash-item-container > StWidget {
-  padding: 0px 4px 0px 5px; }
-  .right .dash-item-container > StWidget, .dash-item-container > StWidget:rtl {
-    padding: 0px 5px 0px 4px; }
-  .bottom .dash-item-container > StWidget {
-    padding: 4px 0px 5px 0px; }
-  .top .dash-item-container > StWidget {
-    padding: 5px 0px 4px 0px; }
+.dash-item-container > StWidget, .dash-item-container > StWidget:rtl, .right .dash-item-container > StWidget {
+  padding: 4px 8px; }
+
+.top .dash-item-container > StWidget, .bottom .dash-item-container > StWidget {
+  padding: 6px; }
 
 .dash-label {
   border-radius: 3px;
   padding: 4px 12px;
-  color: #ffffff;
+  color: white;
   background-color: rgba(0, 0, 0, 0.7);
   text-align: center;
   -x-offset: 3px; }
   .bottom .dash-label, .top .dash-label {
     -y-offset: 3px;
     -x-offset: 0; }
-
-#dash .app-well-app .overview-icon,
-.right #dash .app-well-app .overview-icon,
-.bottom #dash .app-well-app .overview-icon,
-.top #dash .app-well-app .overview-icon {
-  padding: 10px; }
 
 #dash .app-well-app:hover .overview-icon,
 .right #dash .app-well-app:hover .overview-icon,
@@ -1250,7 +1298,7 @@ StScrollBar {
 #dash .app-well-app-running-dot {
   width: 11px;
   height: 2px;
-  margin-bottom: 6px;
+  margin-bottom: 2px;
   background-color: #cc575d; }
 
 #dashtodockContainer .app-well-app-running-dot {
@@ -1271,7 +1319,6 @@ StScrollBar {
   background-image: url("common-assets/dash/running4.svg"); }
 
 .show-apps .overview-icon {
-  padding: 11px;
   background-color: rgba(0, 0, 0, 0.5);
   border-radius: 2px;
   border: 0px solid; }
@@ -1367,7 +1414,7 @@ StScrollBar {
 .list-search-result, .app-well-app .overview-icon,
 .app-well-app.app-folder .overview-icon,
 .grid-search-result .overview-icon {
-  color: #ffffff;
+  color: white;
   border-radius: 2px;
   padding: 6px;
   border: 1px solid transparent;
@@ -1382,6 +1429,7 @@ StScrollBar {
   background-color: rgba(60, 64, 78, 0.95); }
 
 .app-well-app.app-folder:active > .overview-icon, .app-well-app.app-folder:checked > .overview-icon {
+  color: #ffffff;
   background-color: #cc575d;
   box-shadow: none; }
 
@@ -1940,7 +1988,7 @@ StScrollBar {
     padding-left: .3em;
     padding-right: .3em; }
     #LookingGlassDialog .notebook-tab:hover {
-      color: #ffffff;
+      color: white;
       text-shadow: black 0px 2px 2px; }
     #LookingGlassDialog .notebook-tab:selected {
       border-bottom-width: 0px;

--- a/common/gnome-shell/3.18/sass/_colors.scss
+++ b/common/gnome-shell/3.18/sass/_colors.scss
@@ -18,11 +18,18 @@ $link_visited_color: if($variant == 'light', darken($selected_bg_color,20%),
                                      lighten($selected_bg_color,10%));
 
 $selection_mode_bg: if($transparency == 'true', transparentize($selected_bg_color, 0.05), $selected_bg_color);
+$selection_mode_fg: $selected_fg_color;
 $warning_color: #F27835;
 $error_color: #FC4138;
+$warning_fg_color: white;
+$error_fg_color: white;
 $success_color: #73d216;
 $destructive_color: #F04A50;
-$suggested_color: #be3941;
+$suggested_color: #BE3941;
+$destructive_fg_color: white;
+$suggested_fg_color: white;
+
+$drop_target_color: #F08437;
 
 //insensitive state derived colors
 $insensitive_fg_color: if($variant == 'light', transparentize($fg_color, 0.45), transparentize($fg_color, 0.55));

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -30,6 +30,7 @@ $font-family: Futura Bk bt, Cantarell, Sans-Serif;
 $_bubble_bg_color: opacify($osd_bg_color,0.25);
 $_bubble_fg_color: $osd_fg_color;
 $_bubble_borders_color: transparentize($osd_fg_color,0.8);
+$_shell_fg_color: white;
 
 stage {
   font-family: $font-family;
@@ -143,7 +144,7 @@ StScrollBar {
   -slider-active-background-color: $selected_bg_color;        //active trough fill
   -slider-active-border-color: transparentize(black, 1);      //active trough border
   -slider-border-width: 0;
-  -slider-handle-radius: 4px;
+  -slider-handle-radius: 0px;
   height: 18px;
   border: 0 solid transparent;
   border-right-width: 1px;
@@ -353,15 +354,15 @@ StScrollBar {
   }
 
   .modal-dialog-linked-button:last-child {
-    color: $selected_fg_color;
+    color: $destructive_fg_color;
     background-color: $destructive_color;
 
     &:hover {
-      color: $selected_fg_color;
+      color: $destructive_fg_color;
       background-color: lighten($destructive_color, 9%);
     }
     &:active {
-      color: $selected_fg_color;
+      color: $destructive_fg_color;
       background-color: darken($destructive_color, 5%);
     }
   }
@@ -546,7 +547,37 @@ StScrollBar {
   }
 
   &-device-icon { icon-size: 64px; }
-  
+}
+
+//
+// Access Dialog
+//
+.access-dialog {
+  spacing: 30px;
+
+  &-main-layout {
+    padding: 12px 20px 0;
+    spacing: 12px;
+  }
+
+  &-content {
+    max-width: 28em;
+    spacing: 20px;
+  }
+
+  &-icon {
+    min-width: 48px;
+    icon-size: 48px;
+  }
+
+  &-title {
+    font-weight: bold;
+  }
+
+  &-subtitle {
+    color: $fg_color;
+    font-weight: bold;
+  }
 }
 
 //
@@ -685,7 +716,7 @@ StScrollBar {
   min-width: 64px;
   min-height: 64px;
 
-  color: $selected_fg_color;
+  color: $_shell_fg_color;
   background: none;
   border: none;
   border-radius: 5px;
@@ -699,6 +730,10 @@ StScrollBar {
     background-color: transparentize(black, 0.5);
     border-radius: 2px;
     color: $selected_bg_color;
+  }
+  .level-bar {
+    background-color: $selected_bg_color;
+    border-radius: 2px;
   }
 }
 
@@ -731,6 +766,7 @@ StScrollBar {
   .item-box {
     padding: 8px;
     border-radius: 2px;
+    border: 1px solid transparent;
 
     &:outlined {
       padding: 8px;
@@ -765,7 +801,7 @@ StScrollBar {
   color: $osd_fg_color;
 
   &:highlighted {
-    color: $selected_fg_color;
+    color: $_shell_fg_color;
   }
 }
 
@@ -774,6 +810,11 @@ StScrollBar {
   width: 96px;
   height: 96px;
 }
+
+//
+//Window Cycler
+//
+.cycler-highlight { border: 5px solid $selected_bg_color; }
 
 //
 // Workspace Switcher
@@ -843,6 +884,8 @@ StScrollBar {
 // Top Bar
 //
 #panel {
+  $_panel_fg_color: $_shell_fg_color;
+
   font-weight: bold;
   height: 2.1em;
   min-height: 27px;
@@ -888,7 +931,7 @@ StScrollBar {
     -natural-hpadding: 10px;
     -minimum-hpadding: 6px;
     font-weight: bold;
-    color: $selected_fg_color;
+    color: $_panel_fg_color;
     transition-duration: 100ms;
     border-bottom-width: 1px;
     border-color: transparent;
@@ -901,7 +944,7 @@ StScrollBar {
     }
 
     &:hover {
-      color: $selected_fg_color;
+      color: $_panel_fg_color;
       background-color: transparentize(black, 0.83);
       border-bottom-width: 1px;
       border-color: transparent;
@@ -1037,15 +1080,17 @@ StScrollBar {
 .datemenu-today-button,
 .datemenu-displays-box,
 .message-list-sections {
-  margin: 0 1.5em;
+  margin: 0 0.4em;
 }
 
-.datemenu-calendar-column { spacing: 0.5em; }
+.datemenu-calendar-column { spacing: 0.5em; border: none; }
 .datemenu-displays-section { padding-bottom: 3em; }
 
 .datemenu-today-button,
 .world-clocks-button,
-.message-list-section-title {
+.weather-button,
+.message-list-section-title,
+.events-section-title {
   border-radius: 3px;
   padding: .4em;
 }
@@ -1060,7 +1105,9 @@ StScrollBar {
 
 .datemenu-today-button,
 .world-clocks-button,
-.message-list-section-title {
+.weather-button,
+.message-list-section-title,
+.events-section-title {
   padding: 7px 10px 7px 10px;
   border: 1px solid transparentize($base_color, 1);
 
@@ -1076,17 +1123,24 @@ StScrollBar {
 }
 
 .world-clocks-header,
-.message-list-section-title {
+.weather-header,
+.message-list-section-title,
+.events-section-title {
   color: transparentize($fg_color, 0.6);
   font-weight: bold;
 }
 
-.world-clocks-button:active .world-clocks-header {
+.world-clocks-button:active .world-clocks-header,
+.weather-button:active .weather-header {
   color: $selected_fg_color;
 }
 
 .world-clocks-grid {
   spacing-rows: 0.4em;
+}
+
+.weather-box {
+  spacing: 0.4em;
 }
 
 .calendar-month-label {
@@ -1149,7 +1203,7 @@ StScrollBar {
 
   &:hover, &:focus { background-color: transparentize(black, 0.9); }
 
-  &:active {
+  &:active, &:selected {
     color: $fg_color;
     background-color: transparentize(black, 0.85);
     border-width: 0; //avoid jumparound due to today
@@ -1180,6 +1234,7 @@ StScrollBar {
 
 .calendar-today,
 .calendar-today:active,
+.calendar-today:selected,
 .calendar-today:focus,
 .calendar-today:hover {
   font-weight: bold;
@@ -1189,8 +1244,8 @@ StScrollBar {
 }
 
 .calendar-day-with-events {
-  color: $selected_bg_color;
   font-weight: bold;
+  background-image: url("common-assets/misc/calendar-today.svg");
 }
 
 .calendar-today.calendar-day-with-events { color: $selected_fg_color; }
@@ -1227,6 +1282,11 @@ StScrollBar {
   &-placeholder {
     StIcon { width: 0; height: 0; }
     StLabel { color: $insensitive_fg_color; }
+  }
+
+  &-clear-button.button {
+    margin: 1.5em 1.5em 0;
+    padding: 4px 12px;
   }
 
   &-section-close {
@@ -1272,25 +1332,37 @@ StScrollBar {
 
     &:rtl { padding: 8px 8px 8px 0px; }
 
-    > StIcon { icon-size: 32px; }
+    > StIcon {
+      //icon-size: 32px;
+      color: inherit;
+    }
   }
 
-  &-secondary-bin {
-    color: transparentize($fg_color, 0.6);
+  &-secondary-bin,
+  &-secondary-bin > .event-time {
+    color: transparentize($fg_color, 0.4);
+    font-size: 0.9em;
 
     &:ltr { padding-left: 8px; }
     &:rtl { padding-right: 8px; }
   }
 
+  &:active .message-secondary-bin,
+  &:active .message-secondary-bin > .event-time {
+    color: transparentize($selected_fg_color, 0.4);
+  }
+
   &-secondary-bin > StIcon { icon-size: 16px; }
 
   &-title {
+    color: inherit;
     font-weight: bold;
     font-size: 1em;
     padding: 2px 0 2px 0;
   }
 
   &-content {
+    color: inherit;
     padding: 8px;
     font-size: 1em;
   }
@@ -1298,13 +1370,18 @@ StScrollBar {
 
 .message-media-control {
   padding: 6px;
-  color: $insensitive_fg_color;
+  color: $fg_color;
 
   &:last-child:ltr { padding-right: 18px; }
   &:last-child:rtl { padding-left: 18px; }
 
-  &:hover { color: $fg_color; }
+  &:hover { color: transparentize($fg_color, 0.3); }
   &:active { color: $selected_bg_color; }
+  &:insensitive { color: $insensitive_fg_color; }
+}
+
+.message:active .message-media-control {
+  color: $selected_fg_color;
 }
 
 .media-message-cover-icon {
@@ -1521,9 +1598,9 @@ StScrollBar {
 
 .list-search-result-content { spacing: 12px; padding: 12px; }
 
-.list-search-result-title { font-size: 1.5em; color: $selected_fg_color; }
+.list-search-result-title { font-size: 1.5em; color: $_shell_fg_color; }
 
-.list-search-result-description { color: darken($selected_fg_color, 20%); }
+.list-search-result-description { color: darken($_shell_fg_color, 20%); }
 
 .search-provider-icon { padding: 15px; }
 .search-provider-icon-more {
@@ -1540,21 +1617,16 @@ StScrollBar {
   color: $osd_fg_color;
   background-color: $dark_sidebar_bg;
   border-color: rgba(0,0,0,0.4);
-  padding: 6px 1px 6px 0px;
+  padding: 4px 0;
   border-radius: 0 3px 3px 0;
 
   &:rtl { border-radius: 3px 0 0 3px; }
 
   .right &,
-  &:rtl {
-    padding: 6px 0px 6px 1px;
-  }
-  .bottom & {
-    padding: 1px 6px 0px 6px;
-  }
-  .top & {
-    padding: 0px 6px 1px 6px;
-  }
+  &:rtl { padding: 4px 0; }
+
+  .top &, .bottom & { padding: 0; }
+
   .placeholder {
     background-image: url("common-assets/dash/dash-placeholder.svg");
     background-size: contain;
@@ -1568,18 +1640,17 @@ StScrollBar {
 }
 
 .dash-item-container > StWidget {
-  padding: 0px 4px 0px 5px;
 
-  .right &, &:rtl { padding: 0px 5px 0px 4px; }
-  .bottom & { padding: 4px 0px 5px 0px; }
-  .top & { padding: 5px 0px 4px 0px; }
+  &, &:rtl, .right & { padding: 4px 8px; }
+
+  .top &, .bottom & { padding: 6px; }
 }
 
 //osd tooltip
 .dash-label {
   border-radius: 3px;
   padding: 4px 12px;
-  color: $selected_fg_color;
+  color: $_shell_fg_color;
   background-color: transparentize(black, 0.3);
   text-align: center;
   -x-offset: 3px;
@@ -1592,13 +1663,6 @@ StScrollBar {
 
 // Dash Buttons
 #dash .app-well-app {
-
-  .overview-icon,
-  .right & .overview-icon,
-  .bottom & .overview-icon,
-  .top & .overview-icon {
-    padding: 10px;
-  }
 
   &:hover .overview-icon,
   .right &:hover .overview-icon,
@@ -1618,7 +1682,7 @@ StScrollBar {
   &-running-dot {
     width: 11px;
     height: 2px;
-    margin-bottom: 6px;
+    margin-bottom: 2px;
     background-color: $selected_bg_color;
   }
 }
@@ -1640,7 +1704,6 @@ StScrollBar {
 .show-apps {
 
   .overview-icon {
-    padding: 11px;
     background-color: transparentize(black, 0.5);
     border-radius: 2px;
     border: 0px solid;
@@ -1743,7 +1806,7 @@ StScrollBar {
 }
 
 %icon_tile {
-  color: $selected_fg_color;
+  color: $_shell_fg_color;
   border-radius: 2px;
   padding: 6px;
   border: 1px solid transparent;
@@ -1766,6 +1829,7 @@ StScrollBar {
   }
 
   &:active > .overview-icon, &:checked > .overview-icon {
+    color: $selected_fg_color;
     background-color: $selected_bg_color;
     box-shadow: none;
   }
@@ -2321,7 +2385,7 @@ $legacy_icon_size: 24px;
     padding-right: .3em;
 
     &:hover {
-      color: $selected_fg_color;
+      color: $_shell_fg_color;
       text-shadow: black 0px 2px 2px;
     }
     &:selected {

--- a/common/gtk-3.0/3.20/gtk-dark.css
+++ b/common/gtk-3.0/3.20/gtk-dark.css
@@ -4,13 +4,11 @@
   -GtkTextView-error-underline-color: #FC4138;
   -GtkScrolledWindow-scrollbar-spacing: 0;
   -GtkToolItemGroup-expander-size: 11;
-  -GtkTreeView-expander-size: 11;
-  -GtkTreeView-horizontal-separator: 4;
   -GtkWidget-text-handle-width: 20;
   -GtkWidget-text-handle-height: 20;
   -GtkDialog-button-spacing: 4;
   -GtkDialog-action-area-border: 0;
-  outline-color: rgba(211, 218, 227, 0.3);
+  outline-color: alpha(currentColor,0.3);
   outline-style: dashed;
   outline-offset: -3px;
   outline-width: 1px;
@@ -107,7 +105,6 @@ popover.background.magnifier, .csd popover.background.osd, .csd popover.backgrou
   border: none;
   background-color: rgba(53, 57, 69, 0.95);
   background-clip: padding-box;
-  outline-color: rgba(186, 195, 207, 0.3);
   box-shadow: none; }
 
 @keyframes spin {
@@ -133,8 +130,7 @@ entry {
   transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
   color: #D3DAE3;
   border-color: #2b2e39;
-  background-color: #404552;
-  background-image: linear-gradient(to bottom, #404552); }
+  background-color: #404552; }
   entry.search {
     border-radius: 20px; }
   entry image {
@@ -156,51 +152,49 @@ entry {
     color: #D3DAE3;
     border-color: #2b2e39;
     background-color: #404552;
-    background-image: linear-gradient(to bottom, #404552);
     box-shadow: inset 1px 0 #cc575d, inset -1px 0 #cc575d, inset 0 1px #cc575d, inset 0 -1px #cc575d; }
   entry:disabled {
     color: rgba(211, 218, 227, 0.45);
     border-color: rgba(43, 46, 57, 0.55);
-    background-color: rgba(64, 69, 82, 0.55);
-    background-image: linear-gradient(to bottom, rgba(64, 69, 82, 0.55)); }
+    background-color: rgba(64, 69, 82, 0.55); }
   entry.warning {
-    color: #ffffff;
+    color: white;
     border-color: #2b2e39;
-    background-image: linear-gradient(to bottom, #ab6441); }
+    background-color: #ab6441; }
     entry.warning image {
-      color: #ffffff; }
+      color: white; }
     entry.warning:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #F27835);
+      color: white;
+      background-color: #F27835;
       box-shadow: none; }
     entry.warning selection, entry.warning selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #F27835; }
   entry.error {
-    color: #ffffff;
+    color: white;
     border-color: #2b2e39;
-    background-image: linear-gradient(to bottom, #b14342); }
+    background-color: #b14342; }
     entry.error image {
-      color: #ffffff; }
+      color: white; }
     entry.error:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138);
+      color: white;
+      background-color: #FC4138;
       box-shadow: none; }
     entry.error selection, entry.error selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
   entry.search-missing {
-    color: #ffffff;
+    color: white;
     border-color: #2b2e39;
-    background-image: linear-gradient(to bottom, #b14342); }
+    background-color: #b14342; }
     entry.search-missing image {
-      color: #ffffff; }
+      color: white; }
     entry.search-missing:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138);
+      color: white;
+      background-color: #FC4138;
       box-shadow: none; }
     entry.search-missing selection, entry.search-missing selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
   entry:drop(active):focus, entry:drop(active) {
     border-color: #F08437;
@@ -208,17 +202,16 @@ entry {
   .osd entry {
     color: #BAC3CF;
     border-color: rgba(26, 28, 34, 0.35);
-    background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.35));
-    background-color: transparent; }
+    background-color: rgba(102, 109, 132, 0.35); }
     .osd entry image, .osd entry image:hover {
       color: inherit; }
     .osd entry:focus {
       color: #ffffff;
       border-color: rgba(26, 28, 34, 0.35);
-      background-image: linear-gradient(to bottom, #cc575d); }
+      background-color: #cc575d; }
     .osd entry:disabled {
       color: rgba(186, 195, 207, 0.55);
-      background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.2)); }
+      background-color: rgba(102, 109, 132, 0.2); }
     .osd entry selection:focus, .osd entry selection {
       color: #cc575d;
       background-color: #ffffff; }
@@ -253,7 +246,6 @@ button {
   border-radius: 3px;
   padding: 2px 6px;
   color: #D3DAE3;
-  outline-color: rgba(211, 218, 227, 0.3);
   border-color: #2b2e39;
   background-color: #444a58; }
   button separator {
@@ -270,17 +262,18 @@ button {
         transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   button:hover {
     color: #D3DAE3;
-    outline-color: rgba(211, 218, 227, 0.3);
     border-color: #2b2e39;
     background-color: #505666;
     -gtk-icon-effect: highlight; }
   button:active, button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #2b2e39;
     background-color: #cc575d;
     background-clip: padding-box;
     transition-duration: 50ms; }
+    button:active:not(:disabled) label:disabled, button:checked:not(:disabled) label:disabled {
+      color: inherit;
+      opacity: 0.6; }
   button:active {
     color: #D3DAE3; }
   button:active:hover, button:checked {
@@ -328,7 +321,6 @@ button {
     box-shadow: none; }
   button.osd {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     background-color: rgba(53, 57, 69, 0.95);
     border-color: rgba(35, 38, 46, 0.95); }
     button.osd.image-button {
@@ -339,7 +331,6 @@ button {
       color: #cc575d; }
     button.osd:active, button.osd:checked {
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.35);
       background-color: #cc575d; }
     button.osd:disabled {
@@ -348,18 +339,15 @@ button {
       background-color: rgba(102, 109, 132, 0.2); }
   .osd button {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: rgba(102, 109, 132, 0.35); }
     .osd button:hover {
       color: #BAC3CF;
-      outline-color: rgba(186, 195, 207, 0.3);
       border-color: rgba(26, 28, 34, 0.35);
       background-color: rgba(119, 127, 151, 0.45); }
     .osd button:active, .osd button:checked {
       background-clip: padding-box;
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.35);
       background-color: #cc575d; }
     .osd button:disabled {
@@ -373,7 +361,6 @@ button {
       box-shadow: none; }
       .osd button.flat:hover, .osd button.sidebar-button:hover {
         color: #BAC3CF;
-        outline-color: rgba(186, 195, 207, 0.3);
         border-color: rgba(26, 28, 34, 0.35);
         background-color: rgba(119, 127, 151, 0.45); }
       .osd button.flat:disabled, .osd button.sidebar-button:disabled {
@@ -383,7 +370,6 @@ button {
         background-image: none; }
       .osd button.flat:active, .osd button.sidebar-button:active, .osd button.flat:checked, .osd button.sidebar-button:checked {
         color: #ffffff;
-        outline-color: rgba(255, 255, 255, 0.3);
         border-color: rgba(26, 28, 34, 0.35);
         background-color: #cc575d; }
   .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active):not(:only-child),
@@ -391,26 +377,22 @@ button {
     box-shadow: none; }
   button.suggested-action {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
-    background-color: #be3941;
-    border-color: #be3941; }
+    color: white;
+    background-color: #BE3941;
+    border-color: #BE3941; }
     button.suggested-action.flat, button.suggested-action.sidebar-button {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
-      color: #be3941;
-      outline-color: rgba(190, 57, 65, 0.3); }
+      color: #BE3941; }
     button.suggested-action:hover {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #ce5c63;
       border-color: #ce5c63; }
     button.suggested-action:active, button.suggested-action:checked {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #972d34;
       border-color: #972d34; }
     button.suggested-action.flat:disabled, button.suggested-action.sidebar-button:disabled {
@@ -425,26 +407,22 @@ button {
         color: rgba(211, 218, 227, 0.45); }
   button.destructive-action {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #F04A50;
     border-color: #F04A50; }
     button.destructive-action.flat, button.destructive-action.sidebar-button {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
-      color: #F04A50;
-      outline-color: rgba(240, 74, 80, 0.3); }
+      color: #F04A50; }
     button.destructive-action:hover {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #f4797e;
       border-color: #f4797e; }
     button.destructive-action:active, button.destructive-action:checked {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #ec1b22;
       border-color: #ec1b22; }
     button.destructive-action.flat:disabled, button.destructive-action.sidebar-button:disabled {
@@ -484,23 +462,22 @@ button {
     background-position: right 3px, right 2px; }
     .stack-switcher > button.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > image:dir(rtl), button stacksidebar row.needs-attention > label:dir(rtl), stacksidebar button row.needs-attention > label:dir(rtl) {
       background-position: left 3px, left 2px; }
+  button.font separator, button.file separator {
+    background-color: transparent; }
   .inline-toolbar button, .inline-toolbar button:backdrop {
     border-radius: 2px;
     border-width: 1px; }
 
 .inline-toolbar toolbutton > button {
   color: #D3DAE3;
-  outline-color: rgba(211, 218, 227, 0.3);
   border-color: #2b2e39;
   background-color: #444a58; }
   .inline-toolbar toolbutton > button:hover {
     color: #D3DAE3;
-    outline-color: rgba(211, 218, 227, 0.3);
     border-color: #2b2e39;
     background-color: #505666; }
   .inline-toolbar toolbutton > button:active, .inline-toolbar toolbutton > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #2b2e39;
     background-color: #cc575d; }
   .inline-toolbar toolbutton > button:disabled {
@@ -577,12 +554,23 @@ button {
 .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
   box-shadow: inset 1px 0 #2b2e39; }
 
-.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
+  box-shadow: inset 1px 0 rgba(43, 46, 57, 0.5); }
+
 .linked:not(.vertical):not(.path-bar) > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
-.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child) {
+.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:disabled,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked:not(.vertical):not(.path-bar) > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child) {
   box-shadow: none; }
 
 .linked:not(.vertical).path-bar > button + button {
@@ -659,12 +647,23 @@ button {
 .linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
   box-shadow: inset 0 1px #2b2e39; }
 
-.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
+  box-shadow: inset 0 1px rgba(43, 46, 57, 0.5); }
+
 .linked.vertical > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
-.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child) {
+.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:disabled,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked.vertical > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child) {
   box-shadow: none; }
 
 toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat, toolbar.inline-toolbar toolbutton > button.sidebar-button, .inline-toolbar toolbutton > button.sidebar-button, .linked:not(.vertical) > entry,
@@ -710,7 +709,7 @@ toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > bu
   border-style: solid; }
 
 menuitem.button.flat,
-modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover, .app-notification button.flat, .app-notification button.sidebar-button, .app-notification button.flat:disabled, .app-notification button.sidebar-button:disabled {
+modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover, .app-notification button.flat, .app-notification button.sidebar-button, .app-notification button.flat:disabled, .app-notification button.sidebar-button:disabled, calendar.button {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
@@ -761,16 +760,7 @@ modelbutton.flat arrow.right {
     color: #e4a5a8; }
     *:selected *:link:active, *:selected button:active:link, *:selected button:active:visited {
       color: #f5dddf; }
-  .info *:link, .info button:link, .info button:visited,
-  .question *:link,
-  .question button:link,
-  .question button:visited,
-  .warning *:link,
-  .warning button:link,
-  .warning button:visited,
-  .error *:link,
-  .error button:link,
-  .error button:visited, *:link:selected, button:selected:link, button:selected:visited, headerbar.selection-mode .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link,
+  infobar.info *:link, infobar.info button:link, infobar.info button:visited, infobar.question *:link, infobar.question button:link, infobar.question button:visited, infobar.warning *:link, infobar.warning button:link, infobar.warning button:visited, infobar.error *:link, infobar.error button:link, infobar.error button:visited, *:link:selected, button:selected:link, button:selected:visited, headerbar.selection-mode .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link,
   *:selected *:link,
   *:selected button:link,
   *:selected button:visited {
@@ -801,6 +791,10 @@ spinbutton:not(.vertical) > button + button {
 spinbutton:not(.vertical) > button:hover:not(:active),
 spinbutton:not(.vertical) > button:hover + button {
   box-shadow: inset 1px 0 #2b2e39; }
+
+spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover),
+spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled {
+  box-shadow: inset 1px 0 rgba(43, 46, 57, 0.5); }
 
 spinbutton:not(.vertical) > button:first-child:hover:not(:active),
 spinbutton:not(.vertical) > button.up:dir(rtl):hover:not(:active),
@@ -887,7 +881,7 @@ toolbar, .inline-toolbar {
   toolbar:not(.inline-toolbar) .linked > entry, .inline-toolbar:not(.inline-toolbar) .linked > entry {
     margin-right: 0; }
 
-.primary-toolbar {
+.primary-toolbar:not(.libreoffice-toolbar) {
   color: rgba(207, 218, 231, 0.8);
   background-color: #2f343f;
   box-shadow: none;
@@ -1033,22 +1027,21 @@ window.csd > .titlebar:not(headerbar):backdrop {
   box-shadow: none; }
 
 .titlebar:not(headerbar) > separator {
-  background-image: linear-gradient(to top, rgba(38, 42, 51, 0.97)); }
+  background-image: linear-gradient(to bottom, rgba(38, 42, 51, 0.97), rgba(38, 42, 51, 0.97)); }
 
-.primary-toolbar separator, headerbar separator.titlebutton, .titlebar:not(headerbar) separator.titlebutton {
+.primary-toolbar:not(.libreoffice-toolbar) separator, headerbar separator.titlebutton, .titlebar:not(headerbar) separator.titlebutton {
   min-width: 1px;
   min-height: 1px;
   background: none;
   border-width: 0 1px;
   border-image: linear-gradient(to bottom, rgba(207, 218, 231, 0) 25%, rgba(207, 218, 231, 0.15) 25%, rgba(207, 218, 231, 0.15) 75%, rgba(207, 218, 231, 0) 75%) 0 1/0 1px stretch; }
-  .primary-toolbar separator:backdrop, headerbar separator.titlebutton:backdrop, .titlebar:not(headerbar) separator.titlebutton:backdrop {
+  .primary-toolbar:not(.libreoffice-toolbar) separator:backdrop, headerbar separator.titlebutton:backdrop, .titlebar:not(headerbar) separator.titlebutton:backdrop {
     opacity: 0.6; }
 
 .primary-toolbar entry, headerbar entry {
   color: rgba(207, 218, 231, 0.8);
   border-color: rgba(21, 23, 28, 0.37);
-  background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.37));
-  background-color: transparent; }
+  background-color: rgba(95, 105, 127, 0.37); }
   .primary-toolbar entry image, headerbar entry image, .primary-toolbar entry image:hover, headerbar entry image:hover {
     color: inherit; }
   .primary-toolbar entry:backdrop, headerbar entry:backdrop {
@@ -1056,13 +1049,14 @@ window.csd > .titlebar:not(headerbar):backdrop {
   .primary-toolbar entry:focus, headerbar entry:focus {
     color: #ffffff;
     border-color: transparent;
-    background-image: linear-gradient(to bottom, #cc575d);
+    background-color: #cc575d;
     background-clip: padding-box; }
     .primary-toolbar entry:focus image, headerbar entry:focus image {
       color: #ffffff; }
   .primary-toolbar entry:disabled, headerbar entry:disabled {
     color: rgba(207, 218, 231, 0.35);
-    background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.22)); }
+    border-color: rgba(21, 23, 28, 0.37);
+    background-color: rgba(95, 105, 127, 0.22); }
   .primary-toolbar entry selection:focus, headerbar entry selection:focus {
     background-color: #ffffff;
     color: #cc575d; }
@@ -1071,29 +1065,28 @@ window.csd > .titlebar:not(headerbar):backdrop {
     background-image: none;
     background-color: transparent; }
   .primary-toolbar entry.warning, headerbar entry.warning {
-    color: #ffffff;
+    color: white;
     border-color: rgba(21, 23, 28, 0.37);
-    background-image: linear-gradient(to bottom, rgba(167, 94, 57, 0.988)); }
+    background-color: rgba(167, 94, 57, 0.988); }
     .primary-toolbar entry.warning:focus, headerbar entry.warning:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #F27835); }
+      color: white;
+      background-color: #F27835; }
     .primary-toolbar entry.warning selection, headerbar entry.warning selection, .primary-toolbar entry.warning selection:focus, headerbar entry.warning selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #F27835; }
   .primary-toolbar entry.error, headerbar entry.error {
-    color: #ffffff;
+    color: white;
     border-color: rgba(21, 23, 28, 0.37);
-    background-image: linear-gradient(to bottom, rgba(173, 60, 59, 0.988)); }
+    background-color: rgba(173, 60, 59, 0.988); }
     .primary-toolbar entry.error:focus, headerbar entry.error:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138); }
+      color: white;
+      background-color: #FC4138; }
     .primary-toolbar entry.error selection, headerbar entry.error selection, .primary-toolbar entry.error selection:focus, headerbar entry.error selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
 
 .primary-toolbar button, headerbar button {
   color: rgba(207, 218, 231, 0.8);
-  outline-color: rgba(207, 218, 231, 0.1);
   outline-offset: -3px;
   background-color: rgba(47, 52, 63, 0);
   border-color: rgba(47, 52, 63, 0); }
@@ -1101,12 +1094,10 @@ window.csd > .titlebar:not(headerbar):backdrop {
     opacity: 0.7; }
   .primary-toolbar button:hover, headerbar button:hover {
     color: rgba(207, 218, 231, 0.8);
-    outline-color: rgba(207, 218, 231, 0.1);
     border-color: rgba(21, 23, 28, 0.37);
     background-color: rgba(95, 105, 127, 0.37); }
   .primary-toolbar button:active, headerbar button:active, .primary-toolbar button:checked, headerbar button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d;
     background-clip: padding-box; }
@@ -1134,19 +1125,17 @@ window.csd > .titlebar:not(headerbar):backdrop {
   border-radius: 3px;
   border-style: solid; }
 
-.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
   box-shadow: none; }
 
 .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .linked:not(.vertical).path-bar > button, headerbar .linked:not(.vertical).path-bar > button {
   color: rgba(207, 218, 231, 0.8);
-  outline-color: rgba(207, 218, 231, 0.1);
   border-color: rgba(21, 23, 28, 0.37);
   background-color: rgba(95, 105, 127, 0.37); }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar .linked:not(.vertical).path-bar > button:hover, headerbar .linked:not(.vertical).path-bar > button:hover {
     background-color: rgba(134, 144, 165, 0.37); }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar .linked:not(.vertical).path-bar > button:active, headerbar .linked:not(.vertical).path-bar > button:active, .primary-toolbar .linked:not(.vertical).path-bar > button:checked, headerbar .linked:not(.vertical).path-bar > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d; }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, .primary-toolbar .linked:not(.vertical).path-bar > button:disabled, headerbar .linked:not(.vertical).path-bar > button:disabled {
@@ -1205,26 +1194,22 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar button.suggested-action, headerbar button.suggested-action {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
-  background-color: #be3941;
-  border-color: #be3941; }
+  color: white;
+  background-color: #BE3941;
+  border-color: #BE3941; }
   .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat, .primary-toolbar button.suggested-action.sidebar-button, headerbar button.suggested-action.sidebar-button {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
-    color: #be3941;
-    outline-color: rgba(190, 57, 65, 0.3); }
+    color: #BE3941; }
   .primary-toolbar button.suggested-action:hover, headerbar button.suggested-action:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #ce5c63;
     border-color: #ce5c63; }
   .primary-toolbar button.suggested-action:active, headerbar button.suggested-action:active, .primary-toolbar button.suggested-action:checked, headerbar button.suggested-action:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #972d34;
     border-color: #972d34; }
   .primary-toolbar button.suggested-action.flat:disabled, headerbar button.suggested-action.flat:disabled, .primary-toolbar button.suggested-action.sidebar-button:disabled, headerbar button.suggested-action.sidebar-button:disabled, .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
@@ -1238,26 +1223,22 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar button.destructive-action, headerbar button.destructive-action {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
+  color: white;
   background-color: #F04A50;
   border-color: #F04A50; }
   .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat, .primary-toolbar button.destructive-action.sidebar-button, headerbar button.destructive-action.sidebar-button {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
-    color: #F04A50;
-    outline-color: rgba(240, 74, 80, 0.3); }
+    color: #F04A50; }
   .primary-toolbar button.destructive-action:hover, headerbar button.destructive-action:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #f4797e;
     border-color: #f4797e; }
   .primary-toolbar button.destructive-action:active, headerbar button.destructive-action:active, .primary-toolbar button.destructive-action:checked, headerbar button.destructive-action:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #ec1b22;
     border-color: #ec1b22; }
   .primary-toolbar button.destructive-action.flat:disabled, headerbar button.destructive-action.flat:disabled, .primary-toolbar button.destructive-action.sidebar-button:disabled, headerbar button.destructive-action.sidebar-button:disabled, .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
@@ -1275,7 +1256,6 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar spinbutton:not(.vertical) button, headerbar spinbutton:not(.vertical) button, .primary-toolbar spinbutton:not(.vertical) button:disabled, headerbar spinbutton:not(.vertical) button:disabled {
   color: rgba(207, 218, 231, 0.8);
-  outline-color: rgba(207, 218, 231, 0.1);
   border-color: rgba(21, 23, 28, 0.37);
   background-color: rgba(95, 105, 127, 0.37); }
 
@@ -1284,7 +1264,6 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar spinbutton:not(.vertical) button:active, headerbar spinbutton:not(.vertical) button:active, .primary-toolbar spinbutton:not(.vertical) button:checked, headerbar spinbutton:not(.vertical) button:checked {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   border-color: transparent;
   background-color: #cc575d; }
 
@@ -1295,6 +1274,9 @@ window.csd > .titlebar:not(headerbar):backdrop {
   border-left-style: none; }
 
 .primary-toolbar spinbutton:not(.vertical) > button:hover:not(:active), headerbar spinbutton:not(.vertical) > button:hover:not(:active), .primary-toolbar spinbutton:not(.vertical) > button:hover + button, headerbar spinbutton:not(.vertical) > button:hover + button {
+  box-shadow: inset 1px 0 rgba(21, 23, 28, 0.37); }
+
+.primary-toolbar spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover), headerbar spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover), .primary-toolbar spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled, headerbar spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled {
   box-shadow: inset 1px 0 rgba(21, 23, 28, 0.37); }
 
 .primary-toolbar spinbutton:not(.vertical) > button:first-child:hover:not(:active), headerbar spinbutton:not(.vertical) > button:first-child:hover:not(:active), .primary-toolbar spinbutton:not(.vertical) > entry + button:not(:active):hover, headerbar spinbutton:not(.vertical) > entry + button:not(:active):hover {
@@ -1309,18 +1291,18 @@ window.csd > .titlebar:not(headerbar):backdrop {
 .primary-toolbar combobox > .linked > button.combo, headerbar combobox > .linked > button.combo {
   color: rgba(207, 218, 231, 0.8);
   border-color: rgba(21, 23, 28, 0.37);
-  background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.37));
-  background-color: transparent; }
+  background-color: rgba(95, 105, 127, 0.37); }
   .primary-toolbar combobox > .linked > button.combo image, headerbar combobox > .linked > button.combo image, .primary-toolbar combobox > .linked > button.combo image:hover, headerbar combobox > .linked > button.combo image:hover {
     color: inherit; }
   .primary-toolbar combobox > .linked > button.combo:hover, headerbar combobox > .linked > button.combo:hover {
     color: #ffffff;
     border-color: transparent;
-    background-image: linear-gradient(to bottom, #cc575d);
+    background-color: #cc575d;
     box-shadow: none; }
   .primary-toolbar combobox > .linked > button.combo:disabled, headerbar combobox > .linked > button.combo:disabled {
     color: rgba(207, 218, 231, 0.35);
-    background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.22)); }
+    border-color: rgba(21, 23, 28, 0.37);
+    background-color: rgba(95, 105, 127, 0.22); }
 
 .primary-toolbar combobox > .linked > entry.combo:dir(ltr), headerbar combobox > .linked > entry.combo:dir(ltr) {
   border-right-style: none; }
@@ -1393,13 +1375,15 @@ window.csd > .titlebar:not(headerbar):backdrop {
   padding-right: 4px; }
 
 treeview.view {
-  -GtkTreeView-grid-line-width: 1;
-  -GtkTreeView-grid-line-pattern: '';
-  -GtkTreeView-tree-line-width: 1;
-  -GtkTreeView-tree-line-pattern: '';
-  -GtkTreeView-expander-size: 16;
   border-left-color: rgba(211, 218, 227, 0.15);
   border-top-color: rgba(0, 0, 0, 0.1); }
+  * {
+    -GtkTreeView-horizontal-separator: 4;
+    -GtkTreeView-grid-line-width: 1;
+    -GtkTreeView-grid-line-pattern: '';
+    -GtkTreeView-tree-line-width: 1;
+    -GtkTreeView-tree-line-pattern: '';
+    -GtkTreeView-expander-size: 16; }
   treeview.view acceleditor > label {
     background-color: #cc575d; }
   treeview.view:selected, treeview.view:selected:focus {
@@ -1437,16 +1421,21 @@ treeview.view {
   treeview.view.progressbar, treeview.view.progressbar:focus {
     color: #ffffff;
     border-radius: 3px;
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
     treeview.view.progressbar:selected, treeview.view.progressbar:selected:focus, treeview.view.progressbar:focus:selected, treeview.view.progressbar:focus:selected:focus {
       color: #cc575d;
       box-shadow: none;
-      background-image: linear-gradient(to bottom, #ffffff); }
-  treeview.view.trough, treeview.view.trough:selected, treeview.view.trough:selected:focus {
+      background-color: #ffffff; }
+  treeview.view.trough {
     color: #D3DAE3;
-    background-image: linear-gradient(to bottom, #2b2e39);
+    background-color: #2b2e39;
     border-radius: 3px;
     border-width: 0; }
+    treeview.view.trough:selected, treeview.view.trough:selected:focus {
+      color: #ffffff;
+      background-color: rgba(0, 0, 0, 0.2);
+      border-radius: 3px;
+      border-width: 0; }
   treeview.view header button {
     min-height: 0;
     min-width: 0;
@@ -1836,7 +1825,7 @@ scrollbar {
     min-height: 40px; }
 
 switch {
-  font: 1;
+  font-size: 1px;
   min-width: 52px;
   min-height: 24px;
   background-size: 52px 24px;
@@ -2337,9 +2326,11 @@ frame > border,
   padding: 0;
   border-radius: 0;
   border: 1px solid #2b2e39; }
-  frame > border.flat,
-  .frame.flat {
-    border-style: none; }
+
+frame.flat > border,
+frame > border.flat,
+.frame.flat {
+  border-style: none; }
 
 scrolledwindow viewport.frame {
   border-style: none; }
@@ -2471,19 +2462,16 @@ row.activatable:selected.has-open-popup, row.activatable:selected:hover {
     border: none; }
   .app-notification button {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: rgba(102, 109, 132, 0.35); }
     .app-notification button.flat, .app-notification button.sidebar-button {
       border-color: rgba(204, 87, 93, 0); }
     .app-notification button:hover {
       color: #BAC3CF;
-      outline-color: rgba(186, 195, 207, 0.3);
       border-color: rgba(26, 28, 34, 0.35);
       background-color: rgba(119, 127, 151, 0.45); }
     .app-notification button:active, .app-notification button:checked {
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.35);
       background-color: #cc575d;
       background-clip: padding-box; }
@@ -2509,24 +2497,16 @@ calendar {
   border-radius: 3px;
   padding: 2px; }
   calendar:selected {
-    background-color: #cc575d;
-    color: #ffffff;
     border-radius: 1.5px; }
   calendar.header {
     color: #D3DAE3;
-    border: none;
-    border-radius: 0; }
-  calendar.button, calendar.button:focus {
-    color: rgba(211, 218, 227, 0.45);
-    border-color: transparent;
-    background-color: transparent;
-    background-image: none; }
-    calendar.button:hover, calendar.button:focus:hover {
+    border: none; }
+  calendar.button {
+    color: rgba(211, 218, 227, 0.45); }
+    calendar.button:hover {
       color: #D3DAE3; }
-    calendar.button:disabled, calendar.button:focus:disabled {
-      color: rgba(211, 218, 227, 0.45);
-      background-color: transparent;
-      background-image: none; }
+    calendar.button:disabled {
+      color: rgba(211, 218, 227, 0.45); }
   calendar:indeterminate {
     color: alpha(currentColor,0.55); }
   calendar.highlight {
@@ -2627,7 +2607,7 @@ placessidebar row {
   placessidebar row.sidebar-placeholder-row {
     padding: 0 8px;
     min-height: 2px;
-    background-image: linear-gradient(to top, #F08437);
+    background-image: linear-gradient(to bottom, #F08437, #F08437);
     background-clip: content-box; }
   placessidebar row.sidebar-new-bookmark-row {
     color: #cc575d; }
@@ -2657,15 +2637,15 @@ paned > separator {
   -gtk-icon-source: none;
   border-style: none;
   background-color: transparent;
-  background-image: linear-gradient(to top, #2b2e39);
+  background-image: linear-gradient(to bottom, #2b2e39, #2b2e39);
   background-size: 1px 1px; }
   paned > separator:selected {
-    background-image: linear-gradient(to top, #cc575d); }
+    background-image: linear-gradient(to bottom, #cc575d, #cc575d); }
   paned > separator.wide {
     min-width: 5px;
     min-height: 5px;
     background-color: #383C4A;
-    background-image: linear-gradient(to top, #2b2e39), linear-gradient(to top, #2b2e39);
+    background-image: linear-gradient(to bottom, #2b2e39, #2b2e39), linear-gradient(to bottom, #2b2e39, #2b2e39);
     background-size: 1px 1px, 1px 1px; }
 
 paned.horizontal > separator {
@@ -2697,107 +2677,44 @@ paned.vertical > separator {
 
 infobar {
   border-style: none; }
+  infobar.info, infobar.question, infobar.warning, infobar.error {
+    background-color: #cc575d;
+    color: #ffffff;
+    caret-color: currentColor; }
+    infobar.info selection, infobar.question selection, infobar.warning selection, infobar.error selection {
+      color: #cc575d;
+      background-color: #ffffff; }
 
-.info,
-.question,
-.warning,
-.error {
-  background-color: #cc575d;
-  color: #ffffff; }
-  .info label:selected:focus, .info label:selected:hover, .info label:selected,
-  .question label:selected:focus,
-  .question label:selected:hover,
-  .question label:selected,
-  .warning label:selected:focus,
-  .warning label:selected:hover,
-  .warning label:selected,
-  .error label:selected:focus,
-  .error label:selected:hover,
-  .error label:selected {
-    color: #cc575d;
-    background-color: #ffffff; }
-
-.selection-mode.primary-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, .info button,
-.question button,
-.warning button,
-.error button, .nautilus-window .floating-bar button {
+.selection-mode.primary-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, infobar.info button, infobar.question button, infobar.warning button, infobar.error button, .nautilus-window .floating-bar button {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.5); }
 
-row:selected button.flat, row:selected button.sidebar-button, .info button.flat, .info button.sidebar-button,
-.question button.flat,
-.question button.sidebar-button,
-.warning button.flat,
-.warning button.sidebar-button,
-.error button.flat,
-.error button.sidebar-button, .nautilus-window .floating-bar button.flat, .nautilus-window .floating-bar button.sidebar-button {
+row:selected button.flat, row:selected button.sidebar-button, infobar.info button.flat, infobar.info button.sidebar-button, infobar.question button.flat, infobar.question button.sidebar-button, infobar.warning button.flat, infobar.warning button.sidebar-button, infobar.error button.flat, infobar.error button.sidebar-button, .nautilus-window .floating-bar button.flat, .nautilus-window .floating-bar button.sidebar-button {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0); }
-  .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, row:selected button.flat:disabled, row:selected button.sidebar-button:disabled, .info button.flat:disabled, .info button.sidebar-button:disabled,
-  .question button.flat:disabled,
-  .question button.sidebar-button:disabled,
-  .warning button.flat:disabled,
-  .warning button.sidebar-button:disabled,
-  .error button.flat:disabled,
-  .error button.sidebar-button:disabled, .nautilus-window .floating-bar button.flat:disabled, .nautilus-window .floating-bar button.sidebar-button:disabled, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled label, row:selected button.sidebar-button:disabled label, .info button.flat:disabled label, .info button.sidebar-button:disabled label,
-  .question button.flat:disabled label,
-  .question button.sidebar-button:disabled label,
-  .warning button.flat:disabled label,
-  .warning button.sidebar-button:disabled label,
-  .error button.flat:disabled label,
-  .error button.sidebar-button:disabled label, .nautilus-window .floating-bar button.flat:disabled label, .nautilus-window .floating-bar button.sidebar-button:disabled label {
+  .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, row:selected button.flat:disabled, row:selected button.sidebar-button:disabled, infobar.info button.flat:disabled, infobar.info button.sidebar-button:disabled, infobar.question button.flat:disabled, infobar.question button.sidebar-button:disabled, infobar.warning button.flat:disabled, infobar.warning button.sidebar-button:disabled, infobar.error button.flat:disabled, infobar.error button.sidebar-button:disabled, .nautilus-window .floating-bar button.flat:disabled, .nautilus-window .floating-bar button.sidebar-button:disabled, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled label, row:selected button.sidebar-button:disabled label, infobar.info button.flat:disabled label, infobar.info button.sidebar-button:disabled label, infobar.question button.flat:disabled label, infobar.question button.sidebar-button:disabled label, infobar.warning button.flat:disabled label, infobar.warning button.sidebar-button:disabled label, infobar.error button.flat:disabled label, infobar.error button.sidebar-button:disabled label, .nautilus-window .floating-bar button.flat:disabled label, .nautilus-window .floating-bar button.sidebar-button:disabled label {
     color: rgba(255, 255, 255, 0.4); }
 
-row:selected button:hover, .info button:hover,
-.question button:hover,
-.warning button:hover,
-.error button:hover, .nautilus-window .floating-bar button:hover {
+row:selected button:hover, infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover, .nautilus-window .floating-bar button:hover {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   background-color: rgba(255, 255, 255, 0.2);
   border-color: rgba(255, 255, 255, 0.8); }
 
-.selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, .info button:active,
-.question button:active,
-.warning button:active,
-.error button:active, .nautilus-window .floating-bar button:active, .selection-mode.primary-toolbar button:hover:active, headerbar.selection-mode button:hover:active, .selection-mode.primary-toolbar button:hover:checked, headerbar.selection-mode button:hover:checked, row:selected button:active:hover, .info button:active:hover,
-.question button:active:hover,
-.warning button:active:hover,
-.error button:active:hover, .nautilus-window .floating-bar button:active:hover, row:selected button:checked, .info button:checked,
-.question button:checked,
-.warning button:checked,
-.error button:checked, .nautilus-window .floating-bar button:checked {
+.selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, .nautilus-window .floating-bar button:active, .selection-mode.primary-toolbar button:hover:active, headerbar.selection-mode button:hover:active, .selection-mode.primary-toolbar button:hover:checked, headerbar.selection-mode button:hover:checked, row:selected button:active:hover, infobar.info button:active:hover, infobar.question button:active:hover, infobar.warning button:active:hover, infobar.error button:active:hover, .nautilus-window .floating-bar button:active:hover, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked, .nautilus-window .floating-bar button:checked {
   color: #cc575d;
-  outline-color: rgba(204, 87, 93, 0.3);
   background-color: #ffffff;
   border-color: #ffffff; }
 
-row:selected button:disabled, .info button:disabled,
-.question button:disabled,
-.warning button:disabled,
-.error button:disabled, .nautilus-window .floating-bar button:disabled {
+row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, .nautilus-window .floating-bar button:disabled {
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.4); }
-  row:selected button:disabled, .info button:disabled,
-  .question button:disabled,
-  .warning button:disabled,
-  .error button:disabled, .nautilus-window .floating-bar button:disabled, row:selected button:disabled label, .info button:disabled label,
-  .question button:disabled label,
-  .warning button:disabled label,
-  .error button:disabled label, .nautilus-window .floating-bar button:disabled label {
+  row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, .nautilus-window .floating-bar button:disabled, row:selected button:disabled label, infobar.info button:disabled label, infobar.question button:disabled label, infobar.warning button:disabled label, infobar.error button:disabled label, .nautilus-window .floating-bar button:disabled label {
     color: rgba(255, 255, 255, 0.5); }
-  .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, row:selected button:disabled:active, .info button:disabled:active,
-  .question button:disabled:active,
-  .warning button:disabled:active,
-  .error button:disabled:active, .nautilus-window .floating-bar button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:checked, .info button:disabled:checked,
-  .question button:disabled:checked,
-  .warning button:disabled:checked,
-  .error button:disabled:checked, .nautilus-window .floating-bar button:disabled:checked {
+  .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, .nautilus-window .floating-bar button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked, .nautilus-window .floating-bar button:disabled:checked {
     color: #cc575d;
     background-color: rgba(255, 255, 255, 0.5);
     border-color: rgba(255, 255, 255, 0.4); }
@@ -2872,12 +2789,10 @@ colorswatch#add-color-button {
   border-style: solid;
   border-width: 1px;
   color: #D3DAE3;
-  outline-color: rgba(211, 218, 227, 0.3);
   border-color: #2b2e39;
   background-color: #444a58; }
   colorswatch#add-color-button:hover {
     color: #D3DAE3;
-    outline-color: rgba(211, 218, 227, 0.3);
     border-color: #2b2e39;
     background-color: #505666; }
   colorswatch#add-color-button overlay {
@@ -2901,7 +2816,6 @@ colorchooser .popover.osd {
 
 .scale-popup button:hover {
   color: #D3DAE3;
-  outline-color: rgba(211, 218, 227, 0.3);
   border-color: #2b2e39;
   background-color: #505666; }
 
@@ -2910,13 +2824,14 @@ popover.background.touch-selection, .csd popover.background.touch-selection {
   font: initial; }
 
 .monospace {
-  font: Monospace; }
+  font-family: Monospace; }
 
 button.circular, button.nautilus-circular-button.image-button,
 button.circular-button {
   padding: 0;
-  min-width: 26px;
-  min-height: 26px;
+  min-width: 16px;
+  min-height: 24px;
+  padding: 2px 6px;
   border-radius: 50%;
   -gtk-outline-radius: 50%; }
   button.circular label, button.nautilus-circular-button.image-button label,
@@ -2994,14 +2909,12 @@ headerbar button.titlebutton,
   headerbar button.titlebutton:hover,
   .titlebar button.titlebutton:hover {
     color: rgba(207, 218, 231, 0.8);
-    outline-color: rgba(207, 218, 231, 0.1);
     border-color: rgba(21, 23, 28, 0.37);
     background-color: rgba(95, 105, 127, 0.37); }
   headerbar button.titlebutton:active, headerbar button.titlebutton:checked,
   .titlebar button.titlebutton:active,
   .titlebar button.titlebutton:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d; }
   headerbar button.titlebutton.close, headerbar button.titlebutton.maximize, headerbar button.titlebutton.minimize,
@@ -3063,7 +2976,7 @@ textview text selection, flowbox flowboxchild:selected, entry selection:focus, e
 modelbutton.flat:active,
 modelbutton.flat:active arrow,
 modelbutton.flat:selected,
-modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
+modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, calendar:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
 .nautilus-window placessidebar.sidebar row.sidebar-row.has-open-popup:selected,
 .nautilus-window placessidebar.sidebar row.sidebar-row:selected,
 .nautilus-window placessidebar.sidebar row.sidebar-row:selected:hover,
@@ -3077,20 +2990,19 @@ modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:
   modelbutton.flat:active,
   modelbutton.flat:active arrow,
   modelbutton.flat:selected,
-  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
+  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, calendar:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
   .nautilus-window placessidebar.sidebar row.sidebar-row.has-open-popup:selected,
   .nautilus-window placessidebar.sidebar row.sidebar-row:selected,
   .nautilus-window placessidebar.sidebar row.sidebar-row:selected:hover,
   .nautilus-window placessidebar.sidebar row.sidebar-row:active:hover {
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3); }
+    color: #ffffff; }
     row:selected label:disabled, label:disabled:selected, .view:disabled:selected, iconview:disabled:selected, iconview:disabled:selected:focus, .view text:disabled:selected, iconview text:disabled:selected,
     textview text:disabled:selected, iconview text selection:disabled:focus, .view text selection:disabled, iconview text selection:disabled,
     textview text selection:disabled, flowbox flowboxchild:disabled:selected, label:disabled selection, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
     modelbutton.flat:disabled:active,
     modelbutton.flat:active arrow:disabled,
     modelbutton.flat:disabled:selected,
-    modelbutton.flat:selected arrow:disabled, treeview.view:disabled:selected:focus, row:disabled:selected, .nemo-window .nemo-window-pane widget.entry:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:active:hover,
+    modelbutton.flat:selected arrow:disabled, treeview.view:disabled:selected:focus, row:disabled:selected, calendar:disabled:selected, .nemo-window .nemo-window-pane widget.entry:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:active:hover,
     .nautilus-window placessidebar.sidebar row.sidebar-row:disabled:selected,
     .nautilus-window placessidebar.sidebar row.sidebar-row:disabled:active:hover {
       color: #e6abae; }
@@ -3099,10 +3011,12 @@ modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:
 terminal-window notebook > header.top > tabs > tab:checked {
   box-shadow: inset 0 -1px #2b2e39; }
 
-terminal-window notebook > header.top {
+terminal-window notebook > header.top,
+.mate-terminal notebook > header.top {
   padding-top: 3px;
   box-shadow: inset 0 1px #262a33, inset 0 -1px #2b2e39; }
-  terminal-window notebook > header.top button {
+  terminal-window notebook > header.top button,
+  .mate-terminal notebook > header.top button {
     padding: 0;
     min-width: 24px;
     min-height: 24px; }
@@ -3111,7 +3025,7 @@ terminal-window notebook > header.top {
   border-radius: 2px; }
 
 .nautilus-desktop.nautilus-canvas-item, .nemo-desktop.nemo-canvas-item, .caja-desktop {
-  color: #ffffff;
+  color: white;
   text-shadow: 1px 1px rgba(0, 0, 0, 0.6); }
   .nautilus-desktop.nautilus-canvas-item:active, .nemo-desktop.nemo-canvas-item:active, .caja-desktop:active {
     color: #D3DAE3; }
@@ -3154,12 +3068,10 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
 @keyframes needs_attention_keyframes {
   0% {
     color: rgba(207, 218, 231, 0.8);
-    outline-color: rgba(207, 218, 231, 0.1);
     border-color: rgba(21, 23, 28, 0.37);
     background-color: rgba(95, 105, 127, 0.37); }
   100% {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d; } }
 
@@ -3169,6 +3081,17 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
 .nautilus-operations-button-needs-attention-multiple {
   animation: needs_attention_keyframes 3s ease-in-out;
   animation-iteration-count: 3; }
+
+.conflict-row.activatable, .conflict-row.activatable:active {
+  color: white;
+  background-color: #FC4138; }
+
+.conflict-row.activatable:hover {
+  background-color: #fd716a; }
+
+.conflict-row.activatable:selected {
+  color: #ffffff;
+  background-color: #cc575d; }
 
 .nemo-window .nemo-places-sidebar.frame {
   border-width: 0; }
@@ -3182,12 +3105,10 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
   color: #D3DAE3;
   border-color: #2b2e39;
   background-color: #404552;
-  background-image: linear-gradient(to bottom, #404552);
   box-shadow: inset 1px 0 #cc575d, inset -1px 0 #cc575d, inset 0 1px #cc575d, inset 0 -1px #cc575d; }
 
 .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button {
   color: rgba(207, 218, 231, 0.8);
-  outline-color: rgba(207, 218, 231, 0.1);
   border-color: rgba(21, 23, 28, 0.37);
   background-color: rgba(95, 105, 127, 0.37); }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:not(:last-child):not(:only-child) {
@@ -3196,7 +3117,6 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
     background-color: rgba(134, 144, 165, 0.37); }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:active, .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d; }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:disabled {
@@ -3290,6 +3210,26 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
   margin: 2px;
   padding: 2px; }
 
+.gedit-map-frame border {
+  border-width: 0; }
+  .gedit-map-frame border:dir(ltr) {
+    border-left-width: 1px; }
+  .gedit-map-frame border:dir(rtl) {
+    border-right-width: 1px; }
+
+.pluma-window statusbar frame > border {
+  border: none; }
+
+.pluma-window notebook > stack scrolledwindow {
+  border-width: 0 0 1px 0; }
+
+#pluma-status-combo-button {
+  min-height: 0;
+  padding: 0;
+  border-top: none;
+  border-bottom: none;
+  border-radius: 0; }
+
 .gb-search-entry-occurrences-tag {
   background: none; }
 
@@ -3318,6 +3258,8 @@ pillbox {
   color: #ffffff;
   background-color: #cc575d;
   border-radius: 3px; }
+  pillbox:disabled label {
+    color: rgba(255, 255, 255, 0.5); }
 
 docktabstrip {
   padding: 0 6px;
@@ -3350,6 +3292,62 @@ dockoverlayedge {
   dockoverlayedge.left-edge tab:checked,
   dockoverlayedge.right-edge tab:checked {
     border-width: 1px 0; }
+
+popover.messagepopover.background {
+  padding: 0; }
+
+popover.messagepopover .popover-content-area {
+  margin: 16px; }
+
+popover.messagepopover .popover-action-area {
+  margin: 8px; }
+  popover.messagepopover .popover-action-area button:not(:first-child):not(:last-child) {
+    margin: 0 4px; }
+
+popover.popover-selector {
+  padding: 0; }
+  popover.popover-selector list row {
+    padding: 5px 0; }
+  popover.popover-selector list row image {
+    margin-left: 3px;
+    margin-right: 10px; }
+
+entry.search.preferences-search {
+  border: none;
+  border-right: 1px solid #2b2e39;
+  border-bottom: 1px solid #2b2e39;
+  border-radius: 0; }
+
+preferences stacksidebar.sidebar list {
+  background-image: linear-gradient(to bottom, #404552, #404552); }
+
+preferences stacksidebar.sidebar list separator {
+  background-color: transparent; }
+
+devhelppanel entry:focus,
+symboltreepanel entry:focus {
+  border-color: #2b2e39; }
+
+button.run-arrow-button {
+  min-width: 12px; }
+
+omnibar.linked > entry:not(:only-child) {
+  border-style: solid;
+  border-radius: 3px;
+  margin-left: 1px;
+  margin-right: 1px; }
+
+gstyleslidein #scale_box button.toggle:checked,
+gstyleslidein #strings_controls button.toggle:checked,
+gstyleslidein #palette_controls button.toggle:checked,
+gstyleslidein #components_controls button.toggle:checked {
+  color: #D3DAE3; }
+
+configurationview entry.flat {
+  background: none; }
+
+configurationview list {
+  border-width: 0; }
 
 .documents-scrolledwin.frame {
   border-width: 0; }
@@ -3398,46 +3396,119 @@ button.documents-favorite:active:hover {
   opacity: 0.0;
   transition: opacity 0.2s ease-out; }
 
+.tweak-categories,
+.tweak-category:not(:selected):not(:hover) {
+  background-image: linear-gradient(to bottom, #404552, #404552); }
+
 .tr-workarea undershoot,
 .tr-workarea overshoot {
   border-color: transparent; }
 
-.gnome-panel-menu-bar, .gnome-panel-menu-bar menubar,
-.mate-panel-menu-bar,
-.mate-panel-menu-bar menubar {
-  background-color: rgba(43, 46, 55, 0.95); }
+.atril-window .primary-toolbar toolbar, .atril-window .primary-toolbar .inline-toolbar {
+  background: none; }
 
-.gnome-panel-menu-bar menubar,
-.gnome-panel-menu-bar #PanelApplet label,
-.gnome-panel-menu-bar #PanelApplet image,
+#gf-bubble, #gf-bubble.solid,
+#gf-osd-window,
+#gf-osd-window.solid,
+#gf-input-source-popup,
+#gf-input-source-popup.solid,
+#gf-candidate-popup,
+#gf-candidate-popup.solid {
+  color: #cfd5de;
+  background-color: rgba(53, 57, 69, 0.95);
+  border: 1px solid rgba(35, 38, 46, 0.95);
+  border-radius: 2px; }
+
+#gf-bubble levelbar block.low, #gf-bubble levelbar block.high, #gf-bubble levelbar block.full,
+#gf-osd-window levelbar block.low,
+#gf-osd-window levelbar block.high,
+#gf-osd-window levelbar block.full,
+#gf-input-source-popup levelbar block.low,
+#gf-input-source-popup levelbar block.high,
+#gf-input-source-popup levelbar block.full,
+#gf-candidate-popup levelbar block.low,
+#gf-candidate-popup levelbar block.high,
+#gf-candidate-popup levelbar block.full {
+  background-color: #cc575d;
+  border-color: #cc575d; }
+
+#gf-bubble levelbar block.empty,
+#gf-osd-window levelbar block.empty,
+#gf-input-source-popup levelbar block.empty,
+#gf-candidate-popup levelbar block.empty {
+  background-color: rgba(42, 45, 55, 0.95); }
+
+#gf-bubble levelbar trough,
+#gf-osd-window levelbar trough,
+#gf-input-source-popup levelbar trough,
+#gf-candidate-popup levelbar trough {
+  background: none; }
+
+#gf-input-source {
+  min-height: 32px;
+  min-width: 40px; }
+  #gf-input-source:selected {
+    color: #ffffff;
+    background-color: #cc575d;
+    border-radius: 2px; }
+
+gf-candidate-box label {
+  padding: 3px; }
+
+gf-candidate-box:hover, gf-candidate-box:selected {
+  color: #ffffff;
+  background-color: #cc575d;
+  border-radius: 2px; }
+
+MsdOsdWindow.background.osd {
+  border-radius: 2px;
+  border: 1px solid rgba(35, 38, 46, 0.95); }
+  MsdOsdWindow.background.osd .progressbar {
+    background-color: #cc575d;
+    border: none;
+    border-color: red;
+    border-radius: 5px; }
+  MsdOsdWindow.background.osd .trough {
+    background-color: rgba(42, 45, 55, 0.95);
+    border: none;
+    border-radius: 5px; }
+
+.mate-panel-menu-bar, .mate-panel-menu-bar menubar,
+panel-toplevel.background,
+panel-toplevel.background menubar {
+  background-color: #2b2e37; }
+
 .mate-panel-menu-bar menubar,
 .mate-panel-menu-bar #PanelApplet label,
-.mate-panel-menu-bar #PanelApplet image {
+.mate-panel-menu-bar #PanelApplet image,
+panel-toplevel.background menubar,
+panel-toplevel.background #PanelApplet label,
+panel-toplevel.background #PanelApplet image {
   color: #BAC3CF; }
 
-.gnome-panel-menu-bar button label, .gnome-panel-menu-bar button image,
-.gnome-panel-menu-bar #tasklist-button label,
-.gnome-panel-menu-bar #tasklist-button image,
-.mate-panel-menu-bar button label,
-.mate-panel-menu-bar button image,
+.mate-panel-menu-bar button label, .mate-panel-menu-bar button image,
 .mate-panel-menu-bar #tasklist-button label,
-.mate-panel-menu-bar #tasklist-button image {
+.mate-panel-menu-bar #tasklist-button image,
+panel-toplevel.background button label,
+panel-toplevel.background button image,
+panel-toplevel.background #tasklist-button label,
+panel-toplevel.background #tasklist-button image {
   color: inherit; }
 
-.gnome-panel-menu-bar .wnck-pager,
-.mate-panel-menu-bar .wnck-pager {
+.mate-panel-menu-bar .wnck-pager,
+panel-toplevel.background .wnck-pager {
   color: #5d6268;
   background-color: rgba(20, 22, 27, 0.95); }
-  .gnome-panel-menu-bar .wnck-pager:hover,
-  .mate-panel-menu-bar .wnck-pager:hover {
+  .mate-panel-menu-bar .wnck-pager:hover,
+  panel-toplevel.background .wnck-pager:hover {
     background-color: rgba(54, 58, 70, 0.95); }
-  .gnome-panel-menu-bar .wnck-pager:selected,
-  .mate-panel-menu-bar .wnck-pager:selected {
+  .mate-panel-menu-bar .wnck-pager:selected,
+  panel-toplevel.background .wnck-pager:selected {
     color: #e4a5a8;
     background-color: #cc575d; }
 
-.gnome-panel-menu-bar na-tray-applet,
-.mate-panel-menu-bar na-tray-applet {
+.mate-panel-menu-bar na-tray-applet,
+panel-toplevel.background na-tray-applet {
   -NaTrayApplet-icon-padding: 0;
   -NaTrayApplet-icon-size: 16px; }
 
@@ -3455,26 +3526,32 @@ button.documents-favorite:active:hover {
     color: #d8dde4;
     background-color: rgba(0, 0, 0, 0.17); }
   #tasklist-button:checked {
-    color: #ffffff;
+    color: white;
     background-color: rgba(0, 0, 0, 0.25);
     box-shadow: inset 0 -2px #cc575d; }
 
-.gnome-panel-menu-bar button:not(#tasklist-button),
-.mate-panel-menu-bar button:not(#tasklist-button), .xfce4-panel.panel button.flat, .xfce4-panel.panel button.sidebar-button {
+.mate-panel-menu-bar button:not(#tasklist-button),
+panel-toplevel.background button:not(#tasklist-button), .xfce4-panel.panel button.flat, .xfce4-panel.panel button.sidebar-button {
   color: #BAC3CF;
   border-radius: 0;
   border: none;
   background-color: rgba(43, 46, 55, 0); }
-  .gnome-panel-menu-bar button:hover:not(#tasklist-button),
-  .mate-panel-menu-bar button:hover:not(#tasklist-button), .xfce4-panel.panel button.flat:hover, .xfce4-panel.panel button.sidebar-button:hover {
+  .mate-panel-menu-bar button:hover:not(#tasklist-button),
+  panel-toplevel.background button:hover:not(#tasklist-button), .xfce4-panel.panel button.flat:hover, .xfce4-panel.panel button.sidebar-button:hover {
     border: none;
     background-color: rgba(65, 70, 84, 0.95); }
-  .gnome-panel-menu-bar button:active:not(#tasklist-button),
-  .mate-panel-menu-bar button:active:not(#tasklist-button), .xfce4-panel.panel button.flat:active, .xfce4-panel.panel button.sidebar-button:active, .gnome-panel-menu-bar button:checked:not(#tasklist-button),
-  .mate-panel-menu-bar button:checked:not(#tasklist-button), .xfce4-panel.panel button.flat:checked, .xfce4-panel.panel button.sidebar-button:checked {
+  .mate-panel-menu-bar button:active:not(#tasklist-button),
+  panel-toplevel.background button:active:not(#tasklist-button), .xfce4-panel.panel button.flat:active, .xfce4-panel.panel button.sidebar-button:active, .mate-panel-menu-bar button:checked:not(#tasklist-button),
+  panel-toplevel.background button:checked:not(#tasklist-button), .xfce4-panel.panel button.flat:checked, .xfce4-panel.panel button.sidebar-button:checked {
     color: #ffffff;
     border: none;
     background-color: #cc575d; }
+    .mate-panel-menu-bar button:active:not(#tasklist-button) label,
+    panel-toplevel.background button:active:not(#tasklist-button) label, .xfce4-panel.panel button.flat:active label, .xfce4-panel.panel button.sidebar-button:active label, .mate-panel-menu-bar button:active:not(#tasklist-button) image,
+    panel-toplevel.background button:active:not(#tasklist-button) image, .xfce4-panel.panel button.flat:active image, .xfce4-panel.panel button.sidebar-button:active image, .mate-panel-menu-bar button:checked:not(#tasklist-button) label,
+    panel-toplevel.background button:checked:not(#tasklist-button) label, .xfce4-panel.panel button.flat:checked label, .xfce4-panel.panel button.sidebar-button:checked label, .mate-panel-menu-bar button:checked:not(#tasklist-button) image,
+    panel-toplevel.background button:checked:not(#tasklist-button) image, .xfce4-panel.panel button.flat:checked image, .xfce4-panel.panel button.sidebar-button:checked image {
+      color: inherit; }
 
 .nautilus-window .floating-bar {
   padding: 1px;
@@ -3496,17 +3573,17 @@ button.documents-favorite:active:hover {
   padding-right: 4px;
   color: rgba(207, 218, 231, 0.8);
   border-color: rgba(21, 23, 28, 0.37);
-  background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.37));
-  background-color: transparent; }
+  background-color: rgba(95, 105, 127, 0.37); }
   .marlin-pathbar.pathbar image, .marlin-pathbar.pathbar image:hover {
     color: inherit; }
   .marlin-pathbar.pathbar:focus {
     color: #ffffff;
     border-color: transparent;
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
   .marlin-pathbar.pathbar:disabled {
     color: rgba(207, 218, 231, 0.35);
-    background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.22)); }
+    border-color: rgba(21, 23, 28, 0.37);
+    background-color: rgba(95, 105, 127, 0.22); }
   .marlin-pathbar.pathbar:active, .marlin-pathbar.pathbar:checked {
     color: #cc575d; }
 
@@ -3514,7 +3591,7 @@ button.documents-favorite:active:hover {
   border: 1px solid rgba(0, 0, 0, 0.35);
   border-radius: 3px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  background-image: linear-gradient(to bottom, white);
+  background-image: linear-gradient(to bottom, white, white);
   background-color: transparent; }
   .gala-notification .title, .gala-notification .label {
     color: #5c616c; }
@@ -3581,24 +3658,25 @@ UnityDecoration {
   -UnityDecoration-title-indent: 10px;
   -UnityDecoration-title-fade: 35px;
   -UnityDecoration-title-alignment: 0.0; }
-  UnityDecoration.top {
+  UnityDecoration .top {
     border: 1px solid rgba(32, 35, 43, 0.97);
     border-bottom-width: 0;
     border-radius: 4px 4px 0 0;
     padding: 1px 6px 0 6px;
-    background-image: linear-gradient(to bottom, #2f343f);
+    background-image: linear-gradient(to bottom, #2f343f, #2f343f);
     color: rgba(207, 218, 231, 0.8);
     box-shadow: inset 0 1px rgba(54, 59, 72, 0.97); }
-    UnityDecoration.top:backdrop {
+    UnityDecoration .top:backdrop {
       border-bottom-width: 0;
       color: rgba(207, 218, 231, 0.5); }
-  UnityDecoration.left, UnityDecoration.right, UnityDecoration.bottom, UnityDecoration.left:backdrop, UnityDecoration.right:backdrop, UnityDecoration.bottom:backdrop {
+  UnityDecoration .left, UnityDecoration .right, UnityDecoration .bottom,
+  UnityDecoration .left:backdrop, UnityDecoration .right:backdrop, UnityDecoration .bottom:backdrop {
     background-color: transparent;
-    background-image: linear-gradient(to bottom, rgba(32, 35, 43, 0.97)); }
+    background-image: linear-gradient(to bottom, rgba(32, 35, 43, 0.97), rgba(32, 35, 43, 0.97)); }
 
 UnityPanelWidget,
 .unity-panel {
-  background-image: linear-gradient(to bottom, #2f343f);
+  background-image: linear-gradient(to bottom, #2f343f, #2f343f);
   color: #f6f7f9;
   box-shadow: none; }
   UnityPanelWidget:backdrop,
@@ -3609,7 +3687,7 @@ UnityPanelWidget,
 .unity-panel.menubar .menuitem *:hover {
   border-radius: 0;
   color: #ffffff;
-  background-image: linear-gradient(to bottom, #cc575d);
+  background-image: linear-gradient(to bottom, #cc575d, #cc575d);
   border-bottom: none; }
 
 .lightdm.menu {
@@ -3802,7 +3880,7 @@ GraniteWidgetsWelcome {
 
 GraniteWidgetsWelcome label {
   color: #868b97;
-  font: open sans 11;
+  font-size: 11px;
   text-shadow: none; }
 
 GraniteWidgetsWelcome .h1,
@@ -3822,7 +3900,7 @@ GraniteWidgetsPopOver {
   margin: 0; }
 
 .popover_bg {
-  background-image: linear-gradient(to bottom, #404552);
+  background-image: linear-gradient(to bottom, #404552, #404552);
   border: 1px solid rgba(0, 0, 0, 0.3); }
 
 GraniteWidgetsPopOver .sidebar.view, GraniteWidgetsPopOver iconview.sidebar,
@@ -3833,13 +3911,13 @@ GraniteWidgetsXsEntry entry {
   padding: 4px; }
 
 .h1 {
-  font: open sans 24px; }
+  font-size: 24px; }
 
 .h2 {
-  font: open sans light 18px; }
+  font-size: 18px; }
 
 .h3 {
-  font: open sans 11px; }
+  font-size: 11px; }
 
 .h4,
 .category-label {
@@ -3856,24 +3934,25 @@ GtkListBox .h4 {
 #panel_window {
   background-color: rgba(43, 46, 55, 0.95);
   color: #BAC3CF;
-  font: bold;
+  font-weight: bold;
   box-shadow: inset 0 -1px rgba(27, 29, 35, 0.95); }
-  #panel_window menubar,
-  #panel_window menubar > menuitem {
-    background-color: transparent;
-    color: #BAC3CF;
-    font: bold; }
+  #panel_window menubar {
+    padding-left: 5px; }
+    #panel_window menubar, #panel_window menubar > menuitem {
+      background-color: transparent;
+      color: #BAC3CF;
+      font-weight: bold; }
   #panel_window menubar menuitem:disabled {
     color: rgba(186, 195, 207, 0.5); }
     #panel_window menubar menuitem:disabled label {
       color: inherit; }
   #panel_window menubar menu > menuitem {
-    font: normal; }
+    font-weight: normal; }
 
 #login_window,
 #shutdown_dialog,
 #restart_dialog {
-  font: normal;
+  font-weight: normal;
   border-style: none;
   background-color: transparent;
   color: #D3DAE3; }
@@ -3888,17 +3967,14 @@ GtkListBox .h4 {
 
 #content_frame button {
   color: #D3DAE3;
-  outline-color: rgba(211, 218, 227, 0.3);
   border-color: #2b2e39;
   background-color: #444a58; }
   #content_frame button:hover {
     color: #D3DAE3;
-    outline-color: rgba(211, 218, 227, 0.3);
     border-color: #2b2e39;
     background-color: #505666; }
   #content_frame button:active, #content_frame button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #2b2e39;
     background-color: #cc575d; }
   #content_frame button:disabled {
@@ -3920,17 +3996,14 @@ GtkListBox .h4 {
 
 #buttonbox_frame button {
   color: #BAC3CF;
-  outline-color: rgba(186, 195, 207, 0.3);
   border-color: rgba(26, 28, 34, 0.35);
   background-color: rgba(102, 109, 132, 0.35); }
   #buttonbox_frame button:hover {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: rgba(119, 127, 151, 0.45); }
   #buttonbox_frame button:active, #buttonbox_frame button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: #cc575d; }
   #buttonbox_frame button:disabled {
@@ -3940,9 +4013,9 @@ GtkListBox .h4 {
 
 #login_window #user_combobox {
   color: #D3DAE3;
-  font: 13px; }
+  font-size: 13px; }
   #login_window #user_combobox menu {
-    font: normal; }
+    font-weight: normal; }
 
 #user_image {
   padding: 3px;
@@ -3950,51 +4023,45 @@ GtkListBox .h4 {
 
 #shutdown_button.button {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
+  color: green;
   background-color: #F04A50;
   border-color: #F04A50; }
   #shutdown_button.button:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #f4797e;
     border-color: #f4797e; }
   #shutdown_button.button:active, #shutdown_button.button:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #ec1b22;
     border-color: #ec1b22; }
 
 #restart_button.button {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
-  background-color: #be3941;
-  border-color: #be3941; }
+  color: green;
+  background-color: #BE3941;
+  border-color: #BE3941; }
   #restart_button.button:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #ce5c63;
     border-color: #ce5c63; }
   #restart_button.button:active, #restart_button.button:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #972d34;
     border-color: #972d34; }
 
 #greeter_infobar {
   border-bottom-width: 0;
-  font: bold; }
+  font-weight: bold; }
 
 .nautilus-window paned > separator {
-  background-image: linear-gradient(to top, rgba(42, 45, 55, 0.95)); }
+  background-image: linear-gradient(to bottom, rgba(42, 45, 55, 0.95), rgba(42, 45, 55, 0.95)); }
 
 filechooser paned > separator {
-  background-image: linear-gradient(to top, rgba(42, 45, 55, 0.95)); }
+  background-image: linear-gradient(to bottom, rgba(42, 45, 55, 0.95), rgba(42, 45, 55, 0.95)); }
 
 filechooser.csd.background, filechooser placessidebar list,
 .nautilus-window.csd.background,
@@ -4032,13 +4099,11 @@ filechooser placessidebar.sidebar,
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:hover,
       .nautilus-window placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:hover {
         color: #BAC3CF;
-        outline-color: rgba(186, 195, 207, 0.3);
         border-color: rgba(26, 28, 34, 0.35);
         background-color: rgba(119, 127, 151, 0.45); }
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:active,
       .nautilus-window placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:active {
         color: #ffffff;
-        outline-color: rgba(255, 255, 255, 0.3);
         border-color: #2b2e39;
         background-color: #cc575d; }
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:not(:hover):not(:active) > image,
@@ -4114,6 +4179,12 @@ filechooser actionbar {
 .gedit-bottom-panel-paned {
   background-color: #404552; }
 
+.gedit-side-panel-paned > separator {
+  background-image: linear-gradient(to bottom, rgba(42, 45, 55, 0.95), rgba(42, 45, 55, 0.95)); }
+
+.gedit-bottom-panel-paned > separator {
+  background-image: linear-gradient(to bottom, #2b2e39, #2b2e39); }
+
 .gedit-document-panel {
   background-color: rgba(53, 57, 69, 0.95); }
   .maximized .gedit-document-panel {
@@ -4136,17 +4207,14 @@ filechooser actionbar {
 
 filechooser actionbar button {
   color: #BAC3CF;
-  outline-color: rgba(186, 195, 207, 0.3);
   border-color: rgba(26, 28, 34, 0.35);
   background-color: rgba(102, 109, 132, 0.35); }
   .caja-side-pane > box button:hover:not(:active), filechooser actionbar button:hover {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: rgba(119, 127, 151, 0.45); }
   filechooser actionbar button:active, filechooser actionbar button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: #cc575d; }
   filechooser actionbar button:disabled {
@@ -4157,17 +4225,16 @@ filechooser actionbar button {
 filechooser actionbar entry {
   color: #BAC3CF;
   border-color: rgba(26, 28, 34, 0.35);
-  background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.35));
-  background-color: transparent; }
+  background-color: rgba(102, 109, 132, 0.35); }
   filechooser actionbar entry image, filechooser actionbar entry image:hover {
     color: inherit; }
   filechooser actionbar entry:focus {
     color: #ffffff;
     border-color: rgba(26, 28, 34, 0.35);
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
   filechooser actionbar entry:disabled {
     color: rgba(186, 195, 207, 0.55);
-    background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.2)); }
+    background-color: rgba(102, 109, 132, 0.2); }
 
 filechooser placessidebar.sidebar scrollbar,
 .nautilus-window placessidebar.sidebar scrollbar, .nemo-window .sidebar scrollbar, .caja-side-pane scrollbar {

--- a/common/gtk-3.0/3.20/gtk-darker.css
+++ b/common/gtk-3.0/3.20/gtk-darker.css
@@ -4,13 +4,11 @@
   -GtkTextView-error-underline-color: #FC4138;
   -GtkScrolledWindow-scrollbar-spacing: 0;
   -GtkToolItemGroup-expander-size: 11;
-  -GtkTreeView-expander-size: 11;
-  -GtkTreeView-horizontal-separator: 4;
   -GtkWidget-text-handle-width: 20;
   -GtkWidget-text-handle-height: 20;
   -GtkDialog-button-spacing: 4;
   -GtkDialog-action-area-border: 0;
-  outline-color: rgba(92, 97, 108, 0.3);
+  outline-color: alpha(currentColor,0.3);
   outline-style: dashed;
   outline-offset: -3px;
   outline-width: 1px;
@@ -107,7 +105,6 @@ popover.background.magnifier, .csd popover.background.osd, .csd popover.backgrou
   border: none;
   background-color: rgba(53, 57, 69, 0.95);
   background-clip: padding-box;
-  outline-color: rgba(186, 195, 207, 0.3);
   box-shadow: none; }
 
 @keyframes spin {
@@ -133,8 +130,7 @@ entry {
   transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
   color: #5c616c;
   border-color: #cfd6e6;
-  background-color: #ffffff;
-  background-image: linear-gradient(to bottom, #ffffff); }
+  background-color: #ffffff; }
   entry.search {
     border-radius: 20px; }
   entry image {
@@ -155,51 +151,49 @@ entry {
     background-clip: border-box;
     color: #5c616c;
     border-color: #cc575d;
-    background-color: #ffffff;
-    background-image: linear-gradient(to bottom, #ffffff); }
+    background-color: #ffffff; }
   entry:disabled {
     color: rgba(92, 97, 108, 0.55);
     border-color: rgba(207, 214, 230, 0.55);
-    background-color: rgba(255, 255, 255, 0.55);
-    background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.55)); }
+    background-color: rgba(255, 255, 255, 0.55); }
   entry.warning {
-    color: #ffffff;
+    color: white;
     border-color: #F27835;
-    background-image: linear-gradient(to bottom, #f7ae86); }
+    background-color: #f7ae86; }
     entry.warning image {
-      color: #ffffff; }
+      color: white; }
     entry.warning:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #F27835);
+      color: white;
+      background-color: #F27835;
       box-shadow: none; }
     entry.warning selection, entry.warning selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #F27835; }
   entry.error {
-    color: #ffffff;
+    color: white;
     border-color: #FC4138;
-    background-image: linear-gradient(to bottom, #fd8d88); }
+    background-color: #fd8d88; }
     entry.error image {
-      color: #ffffff; }
+      color: white; }
     entry.error:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138);
+      color: white;
+      background-color: #FC4138;
       box-shadow: none; }
     entry.error selection, entry.error selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
   entry.search-missing {
-    color: #ffffff;
+    color: white;
     border-color: #FC4138;
-    background-image: linear-gradient(to bottom, #fd8d88); }
+    background-color: #fd8d88; }
     entry.search-missing image {
-      color: #ffffff; }
+      color: white; }
     entry.search-missing:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138);
+      color: white;
+      background-color: #FC4138;
       box-shadow: none; }
     entry.search-missing selection, entry.search-missing selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
   entry:drop(active):focus, entry:drop(active) {
     border-color: #F08437;
@@ -207,17 +201,16 @@ entry {
   .osd entry {
     color: #BAC3CF;
     border-color: rgba(26, 28, 34, 0.35);
-    background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.35));
-    background-color: transparent; }
+    background-color: rgba(102, 109, 132, 0.35); }
     .osd entry image, .osd entry image:hover {
       color: inherit; }
     .osd entry:focus {
       color: #ffffff;
       border-color: rgba(26, 28, 34, 0.35);
-      background-image: linear-gradient(to bottom, #cc575d); }
+      background-color: #cc575d; }
     .osd entry:disabled {
       color: rgba(186, 195, 207, 0.55);
-      background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.2)); }
+      background-color: rgba(102, 109, 132, 0.2); }
     .osd entry selection:focus, .osd entry selection {
       color: #cc575d;
       background-color: #ffffff; }
@@ -252,7 +245,6 @@ button {
   border-radius: 3px;
   padding: 2px 6px;
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: #fbfbfc; }
   button separator {
@@ -269,17 +261,18 @@ button {
         transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   button:hover {
     color: #5c616c;
-    outline-color: rgba(92, 97, 108, 0.3);
     border-color: #cfd6e6;
     background-color: white;
     -gtk-icon-effect: highlight; }
   button:active, button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d;
     background-clip: border-box;
     transition-duration: 50ms; }
+    button:active:not(:disabled) label:disabled, button:checked:not(:disabled) label:disabled {
+      color: inherit;
+      opacity: 0.6; }
   button:active {
     color: #5c616c; }
   button:active:hover, button:checked {
@@ -327,7 +320,6 @@ button {
     box-shadow: none; }
   button.osd {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     background-color: rgba(53, 57, 69, 0.95);
     border-color: rgba(35, 38, 46, 0.95); }
     button.osd.image-button {
@@ -338,7 +330,6 @@ button {
       color: #cc575d; }
     button.osd:active, button.osd:checked {
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.35);
       background-color: #cc575d; }
     button.osd:disabled {
@@ -347,18 +338,15 @@ button {
       background-color: rgba(102, 109, 132, 0.2); }
   .osd button {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: rgba(102, 109, 132, 0.35); }
     .osd button:hover {
       color: #BAC3CF;
-      outline-color: rgba(186, 195, 207, 0.3);
       border-color: rgba(26, 28, 34, 0.35);
       background-color: rgba(119, 127, 151, 0.45); }
     .osd button:active, .osd button:checked {
       background-clip: padding-box;
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.35);
       background-color: #cc575d; }
     .osd button:disabled {
@@ -372,7 +360,6 @@ button {
       box-shadow: none; }
       .osd button.flat:hover, .osd button.sidebar-button:hover {
         color: #BAC3CF;
-        outline-color: rgba(186, 195, 207, 0.3);
         border-color: rgba(26, 28, 34, 0.35);
         background-color: rgba(119, 127, 151, 0.45); }
       .osd button.flat:disabled, .osd button.sidebar-button:disabled {
@@ -382,7 +369,6 @@ button {
         background-image: none; }
       .osd button.flat:active, .osd button.sidebar-button:active, .osd button.flat:checked, .osd button.sidebar-button:checked {
         color: #ffffff;
-        outline-color: rgba(255, 255, 255, 0.3);
         border-color: rgba(26, 28, 34, 0.35);
         background-color: #cc575d; }
   .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active):not(:only-child),
@@ -390,26 +376,22 @@ button {
     box-shadow: none; }
   button.suggested-action {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
-    background-color: #be3941;
-    border-color: #be3941; }
+    color: white;
+    background-color: #BE3941;
+    border-color: #BE3941; }
     button.suggested-action.flat, button.suggested-action.sidebar-button {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
-      color: #be3941;
-      outline-color: rgba(190, 57, 65, 0.3); }
+      color: #BE3941; }
     button.suggested-action:hover {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #ce5c63;
       border-color: #ce5c63; }
     button.suggested-action:active, button.suggested-action:checked {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #972d34;
       border-color: #972d34; }
     button.suggested-action.flat:disabled, button.suggested-action.sidebar-button:disabled {
@@ -424,26 +406,22 @@ button {
         color: rgba(92, 97, 108, 0.55); }
   button.destructive-action {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #F04A50;
     border-color: #F04A50; }
     button.destructive-action.flat, button.destructive-action.sidebar-button {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
-      color: #F04A50;
-      outline-color: rgba(240, 74, 80, 0.3); }
+      color: #F04A50; }
     button.destructive-action:hover {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #f4797e;
       border-color: #f4797e; }
     button.destructive-action:active, button.destructive-action:checked {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #ec1b22;
       border-color: #ec1b22; }
     button.destructive-action.flat:disabled, button.destructive-action.sidebar-button:disabled {
@@ -483,23 +461,22 @@ button {
     background-position: right 3px, right 4px; }
     .stack-switcher > button.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > image:dir(rtl), button stacksidebar row.needs-attention > label:dir(rtl), stacksidebar button row.needs-attention > label:dir(rtl) {
       background-position: left 3px, left 4px; }
+  button.font separator, button.file separator {
+    background-color: transparent; }
   .inline-toolbar button, .inline-toolbar button:backdrop {
     border-radius: 2px;
     border-width: 1px; }
 
 .inline-toolbar toolbutton > button {
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: #fbfbfc; }
   .inline-toolbar toolbutton > button:hover {
     color: #5c616c;
-    outline-color: rgba(92, 97, 108, 0.3);
     border-color: #cfd6e6;
     background-color: white; }
   .inline-toolbar toolbutton > button:active, .inline-toolbar toolbutton > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d; }
   .inline-toolbar toolbutton > button:disabled {
@@ -576,12 +553,23 @@ button {
 .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
   box-shadow: inset 1px 0 #cfd6e6; }
 
-.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
+  box-shadow: inset 1px 0 rgba(207, 214, 230, 0.5); }
+
 .linked:not(.vertical):not(.path-bar) > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
-.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child) {
+.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:disabled,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked:not(.vertical):not(.path-bar) > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child) {
   box-shadow: none; }
 
 .linked:not(.vertical).path-bar > button + button {
@@ -658,12 +646,23 @@ button {
 .linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
   box-shadow: inset 0 1px #cfd6e6; }
 
-.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
+  box-shadow: inset 0 1px rgba(207, 214, 230, 0.5); }
+
 .linked.vertical > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
-.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child) {
+.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:disabled,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked.vertical > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child) {
   box-shadow: none; }
 
 toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat, toolbar.inline-toolbar toolbutton > button.sidebar-button, .inline-toolbar toolbutton > button.sidebar-button, .linked:not(.vertical) > entry,
@@ -709,7 +708,7 @@ toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > bu
   border-style: solid; }
 
 menuitem.button.flat,
-modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover, .app-notification button.flat, .app-notification button.sidebar-button, .app-notification button.flat:disabled, .app-notification button.sidebar-button:disabled {
+modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover, .app-notification button.flat, .app-notification button.sidebar-button, .app-notification button.flat:disabled, .app-notification button.sidebar-button:disabled, calendar.button {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
@@ -760,16 +759,7 @@ modelbutton.flat arrow.right {
     color: #b8383e; }
     *:selected *:link:active, *:selected button:active:link, *:selected button:active:visited {
       color: #f5dddf; }
-  .info *:link, .info button:link, .info button:visited,
-  .question *:link,
-  .question button:link,
-  .question button:visited,
-  .warning *:link,
-  .warning button:link,
-  .warning button:visited,
-  .error *:link,
-  .error button:link,
-  .error button:visited, *:link:selected, button:selected:link, button:selected:visited, headerbar.selection-mode .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link,
+  infobar.info *:link, infobar.info button:link, infobar.info button:visited, infobar.question *:link, infobar.question button:link, infobar.question button:visited, infobar.warning *:link, infobar.warning button:link, infobar.warning button:visited, infobar.error *:link, infobar.error button:link, infobar.error button:visited, *:link:selected, button:selected:link, button:selected:visited, headerbar.selection-mode .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link,
   *:selected *:link,
   *:selected button:link,
   *:selected button:visited {
@@ -800,6 +790,10 @@ spinbutton:not(.vertical) > button + button {
 spinbutton:not(.vertical) > button:hover:not(:active),
 spinbutton:not(.vertical) > button:hover + button {
   box-shadow: inset 1px 0 #cfd6e6; }
+
+spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover),
+spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled {
+  box-shadow: inset 1px 0 rgba(207, 214, 230, 0.5); }
 
 spinbutton:not(.vertical) > button:first-child:hover:not(:active),
 spinbutton:not(.vertical) > button.up:dir(rtl):hover:not(:active),
@@ -886,7 +880,7 @@ toolbar, .inline-toolbar {
   toolbar:not(.inline-toolbar) .linked > entry, .inline-toolbar:not(.inline-toolbar) .linked > entry {
     margin-right: 0; }
 
-.primary-toolbar {
+.primary-toolbar:not(.libreoffice-toolbar) {
   color: rgba(207, 218, 231, 0.8);
   background-color: #2f343f;
   box-shadow: none;
@@ -1032,22 +1026,21 @@ window.csd > .titlebar:not(headerbar):backdrop {
   box-shadow: none; }
 
 .titlebar:not(headerbar) > separator {
-  background-image: linear-gradient(to top, rgba(38, 42, 51, 0.97)); }
+  background-image: linear-gradient(to bottom, rgba(38, 42, 51, 0.97), rgba(38, 42, 51, 0.97)); }
 
-.primary-toolbar separator, headerbar separator.titlebutton, .titlebar:not(headerbar) separator.titlebutton {
+.primary-toolbar:not(.libreoffice-toolbar) separator, headerbar separator.titlebutton, .titlebar:not(headerbar) separator.titlebutton {
   min-width: 1px;
   min-height: 1px;
   background: none;
   border-width: 0 1px;
   border-image: linear-gradient(to bottom, rgba(207, 218, 231, 0) 25%, rgba(207, 218, 231, 0.15) 25%, rgba(207, 218, 231, 0.15) 75%, rgba(207, 218, 231, 0) 75%) 0 1/0 1px stretch; }
-  .primary-toolbar separator:backdrop, headerbar separator.titlebutton:backdrop, .titlebar:not(headerbar) separator.titlebutton:backdrop {
+  .primary-toolbar:not(.libreoffice-toolbar) separator:backdrop, headerbar separator.titlebutton:backdrop, .titlebar:not(headerbar) separator.titlebutton:backdrop {
     opacity: 0.6; }
 
 .primary-toolbar entry, headerbar entry {
   color: rgba(207, 218, 231, 0.8);
   border-color: rgba(21, 23, 28, 0.37);
-  background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.37));
-  background-color: transparent; }
+  background-color: rgba(95, 105, 127, 0.37); }
   .primary-toolbar entry image, headerbar entry image, .primary-toolbar entry image:hover, headerbar entry image:hover {
     color: inherit; }
   .primary-toolbar entry:backdrop, headerbar entry:backdrop {
@@ -1055,13 +1048,14 @@ window.csd > .titlebar:not(headerbar):backdrop {
   .primary-toolbar entry:focus, headerbar entry:focus {
     color: #ffffff;
     border-color: transparent;
-    background-image: linear-gradient(to bottom, #cc575d);
+    background-color: #cc575d;
     background-clip: padding-box; }
     .primary-toolbar entry:focus image, headerbar entry:focus image {
       color: #ffffff; }
   .primary-toolbar entry:disabled, headerbar entry:disabled {
     color: rgba(207, 218, 231, 0.35);
-    background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.22)); }
+    border-color: rgba(21, 23, 28, 0.37);
+    background-color: rgba(95, 105, 127, 0.22); }
   .primary-toolbar entry selection:focus, headerbar entry selection:focus {
     background-color: #ffffff;
     color: #cc575d; }
@@ -1070,29 +1064,28 @@ window.csd > .titlebar:not(headerbar):backdrop {
     background-image: none;
     background-color: transparent; }
   .primary-toolbar entry.warning, headerbar entry.warning {
-    color: #ffffff;
+    color: white;
     border-color: rgba(21, 23, 28, 0.37);
-    background-image: linear-gradient(to bottom, rgba(167, 94, 57, 0.988)); }
+    background-color: rgba(167, 94, 57, 0.988); }
     .primary-toolbar entry.warning:focus, headerbar entry.warning:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #F27835); }
+      color: white;
+      background-color: #F27835; }
     .primary-toolbar entry.warning selection, headerbar entry.warning selection, .primary-toolbar entry.warning selection:focus, headerbar entry.warning selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #F27835; }
   .primary-toolbar entry.error, headerbar entry.error {
-    color: #ffffff;
+    color: white;
     border-color: rgba(21, 23, 28, 0.37);
-    background-image: linear-gradient(to bottom, rgba(173, 60, 59, 0.988)); }
+    background-color: rgba(173, 60, 59, 0.988); }
     .primary-toolbar entry.error:focus, headerbar entry.error:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138); }
+      color: white;
+      background-color: #FC4138; }
     .primary-toolbar entry.error selection, headerbar entry.error selection, .primary-toolbar entry.error selection:focus, headerbar entry.error selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
 
 .primary-toolbar button, headerbar button {
   color: rgba(207, 218, 231, 0.8);
-  outline-color: rgba(207, 218, 231, 0.1);
   outline-offset: -3px;
   background-color: rgba(47, 52, 63, 0);
   border-color: rgba(47, 52, 63, 0); }
@@ -1100,12 +1093,10 @@ window.csd > .titlebar:not(headerbar):backdrop {
     opacity: 0.7; }
   .primary-toolbar button:hover, headerbar button:hover {
     color: rgba(207, 218, 231, 0.8);
-    outline-color: rgba(207, 218, 231, 0.1);
     border-color: rgba(21, 23, 28, 0.37);
     background-color: rgba(95, 105, 127, 0.37); }
   .primary-toolbar button:active, headerbar button:active, .primary-toolbar button:checked, headerbar button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d;
     background-clip: padding-box; }
@@ -1133,19 +1124,17 @@ window.csd > .titlebar:not(headerbar):backdrop {
   border-radius: 3px;
   border-style: solid; }
 
-.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
   box-shadow: none; }
 
 .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .linked:not(.vertical).path-bar > button, headerbar .linked:not(.vertical).path-bar > button {
   color: rgba(207, 218, 231, 0.8);
-  outline-color: rgba(207, 218, 231, 0.1);
   border-color: rgba(21, 23, 28, 0.37);
   background-color: rgba(95, 105, 127, 0.37); }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar .linked:not(.vertical).path-bar > button:hover, headerbar .linked:not(.vertical).path-bar > button:hover {
     background-color: rgba(134, 144, 165, 0.37); }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar .linked:not(.vertical).path-bar > button:active, headerbar .linked:not(.vertical).path-bar > button:active, .primary-toolbar .linked:not(.vertical).path-bar > button:checked, headerbar .linked:not(.vertical).path-bar > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d; }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, .primary-toolbar .linked:not(.vertical).path-bar > button:disabled, headerbar .linked:not(.vertical).path-bar > button:disabled {
@@ -1204,26 +1193,22 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar button.suggested-action, headerbar button.suggested-action {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
-  background-color: #be3941;
-  border-color: #be3941; }
+  color: white;
+  background-color: #BE3941;
+  border-color: #BE3941; }
   .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat, .primary-toolbar button.suggested-action.sidebar-button, headerbar button.suggested-action.sidebar-button {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
-    color: #be3941;
-    outline-color: rgba(190, 57, 65, 0.3); }
+    color: #BE3941; }
   .primary-toolbar button.suggested-action:hover, headerbar button.suggested-action:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #ce5c63;
     border-color: #ce5c63; }
   .primary-toolbar button.suggested-action:active, headerbar button.suggested-action:active, .primary-toolbar button.suggested-action:checked, headerbar button.suggested-action:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #972d34;
     border-color: #972d34; }
   .primary-toolbar button.suggested-action.flat:disabled, headerbar button.suggested-action.flat:disabled, .primary-toolbar button.suggested-action.sidebar-button:disabled, headerbar button.suggested-action.sidebar-button:disabled, .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
@@ -1237,26 +1222,22 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar button.destructive-action, headerbar button.destructive-action {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
+  color: white;
   background-color: #F04A50;
   border-color: #F04A50; }
   .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat, .primary-toolbar button.destructive-action.sidebar-button, headerbar button.destructive-action.sidebar-button {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
-    color: #F04A50;
-    outline-color: rgba(240, 74, 80, 0.3); }
+    color: #F04A50; }
   .primary-toolbar button.destructive-action:hover, headerbar button.destructive-action:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #f4797e;
     border-color: #f4797e; }
   .primary-toolbar button.destructive-action:active, headerbar button.destructive-action:active, .primary-toolbar button.destructive-action:checked, headerbar button.destructive-action:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #ec1b22;
     border-color: #ec1b22; }
   .primary-toolbar button.destructive-action.flat:disabled, headerbar button.destructive-action.flat:disabled, .primary-toolbar button.destructive-action.sidebar-button:disabled, headerbar button.destructive-action.sidebar-button:disabled, .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
@@ -1274,7 +1255,6 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar spinbutton:not(.vertical) button, headerbar spinbutton:not(.vertical) button, .primary-toolbar spinbutton:not(.vertical) button:disabled, headerbar spinbutton:not(.vertical) button:disabled {
   color: rgba(207, 218, 231, 0.8);
-  outline-color: rgba(207, 218, 231, 0.1);
   border-color: rgba(21, 23, 28, 0.37);
   background-color: rgba(95, 105, 127, 0.37); }
 
@@ -1283,7 +1263,6 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar spinbutton:not(.vertical) button:active, headerbar spinbutton:not(.vertical) button:active, .primary-toolbar spinbutton:not(.vertical) button:checked, headerbar spinbutton:not(.vertical) button:checked {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   border-color: transparent;
   background-color: #cc575d; }
 
@@ -1294,6 +1273,9 @@ window.csd > .titlebar:not(headerbar):backdrop {
   border-left-style: none; }
 
 .primary-toolbar spinbutton:not(.vertical) > button:hover:not(:active), headerbar spinbutton:not(.vertical) > button:hover:not(:active), .primary-toolbar spinbutton:not(.vertical) > button:hover + button, headerbar spinbutton:not(.vertical) > button:hover + button {
+  box-shadow: inset 1px 0 rgba(21, 23, 28, 0.37); }
+
+.primary-toolbar spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover), headerbar spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover), .primary-toolbar spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled, headerbar spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled {
   box-shadow: inset 1px 0 rgba(21, 23, 28, 0.37); }
 
 .primary-toolbar spinbutton:not(.vertical) > button:first-child:hover:not(:active), headerbar spinbutton:not(.vertical) > button:first-child:hover:not(:active), .primary-toolbar spinbutton:not(.vertical) > entry + button:not(:active):hover, headerbar spinbutton:not(.vertical) > entry + button:not(:active):hover {
@@ -1308,18 +1290,18 @@ window.csd > .titlebar:not(headerbar):backdrop {
 .primary-toolbar combobox > .linked > button.combo, headerbar combobox > .linked > button.combo {
   color: rgba(207, 218, 231, 0.8);
   border-color: rgba(21, 23, 28, 0.37);
-  background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.37));
-  background-color: transparent; }
+  background-color: rgba(95, 105, 127, 0.37); }
   .primary-toolbar combobox > .linked > button.combo image, headerbar combobox > .linked > button.combo image, .primary-toolbar combobox > .linked > button.combo image:hover, headerbar combobox > .linked > button.combo image:hover {
     color: inherit; }
   .primary-toolbar combobox > .linked > button.combo:hover, headerbar combobox > .linked > button.combo:hover {
     color: #ffffff;
     border-color: transparent;
-    background-image: linear-gradient(to bottom, #cc575d);
+    background-color: #cc575d;
     box-shadow: none; }
   .primary-toolbar combobox > .linked > button.combo:disabled, headerbar combobox > .linked > button.combo:disabled {
     color: rgba(207, 218, 231, 0.35);
-    background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.22)); }
+    border-color: rgba(21, 23, 28, 0.37);
+    background-color: rgba(95, 105, 127, 0.22); }
 
 .primary-toolbar combobox > .linked > entry.combo:dir(ltr), headerbar combobox > .linked > entry.combo:dir(ltr) {
   border-right-style: none; }
@@ -1392,13 +1374,15 @@ window.csd > .titlebar:not(headerbar):backdrop {
   padding-right: 4px; }
 
 treeview.view {
-  -GtkTreeView-grid-line-width: 1;
-  -GtkTreeView-grid-line-pattern: '';
-  -GtkTreeView-tree-line-width: 1;
-  -GtkTreeView-tree-line-pattern: '';
-  -GtkTreeView-expander-size: 16;
   border-left-color: rgba(92, 97, 108, 0.15);
   border-top-color: rgba(0, 0, 0, 0.1); }
+  * {
+    -GtkTreeView-horizontal-separator: 4;
+    -GtkTreeView-grid-line-width: 1;
+    -GtkTreeView-grid-line-pattern: '';
+    -GtkTreeView-tree-line-width: 1;
+    -GtkTreeView-tree-line-pattern: '';
+    -GtkTreeView-expander-size: 16; }
   treeview.view acceleditor > label {
     background-color: #cc575d; }
   treeview.view:selected, treeview.view:selected:focus {
@@ -1436,16 +1420,21 @@ treeview.view {
   treeview.view.progressbar, treeview.view.progressbar:focus {
     color: #ffffff;
     border-radius: 3px;
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
     treeview.view.progressbar:selected, treeview.view.progressbar:selected:focus, treeview.view.progressbar:focus:selected, treeview.view.progressbar:focus:selected:focus {
       color: #cc575d;
       box-shadow: none;
-      background-image: linear-gradient(to bottom, #ffffff); }
-  treeview.view.trough, treeview.view.trough:selected, treeview.view.trough:selected:focus {
+      background-color: #ffffff; }
+  treeview.view.trough {
     color: #5c616c;
-    background-image: linear-gradient(to bottom, #cfd6e6);
+    background-color: #cfd6e6;
     border-radius: 3px;
     border-width: 0; }
+    treeview.view.trough:selected, treeview.view.trough:selected:focus {
+      color: #ffffff;
+      background-color: rgba(0, 0, 0, 0.2);
+      border-radius: 3px;
+      border-width: 0; }
   treeview.view header button {
     min-height: 0;
     min-width: 0;
@@ -1835,7 +1824,7 @@ scrollbar {
     min-height: 40px; }
 
 switch {
-  font: 1;
+  font-size: 1px;
   min-width: 52px;
   min-height: 24px;
   background-size: 52px 24px;
@@ -2336,9 +2325,11 @@ frame > border,
   padding: 0;
   border-radius: 0;
   border: 1px solid #dcdfe3; }
-  frame > border.flat,
-  .frame.flat {
-    border-style: none; }
+
+frame.flat > border,
+frame > border.flat,
+.frame.flat {
+  border-style: none; }
 
 scrolledwindow viewport.frame {
   border-style: none; }
@@ -2470,19 +2461,16 @@ row.activatable:selected.has-open-popup, row.activatable:selected:hover {
     border: none; }
   .app-notification button {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: rgba(102, 109, 132, 0.35); }
     .app-notification button.flat, .app-notification button.sidebar-button {
       border-color: rgba(204, 87, 93, 0); }
     .app-notification button:hover {
       color: #BAC3CF;
-      outline-color: rgba(186, 195, 207, 0.3);
       border-color: rgba(26, 28, 34, 0.35);
       background-color: rgba(119, 127, 151, 0.45); }
     .app-notification button:active, .app-notification button:checked {
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.35);
       background-color: #cc575d;
       background-clip: padding-box; }
@@ -2508,24 +2496,16 @@ calendar {
   border-radius: 3px;
   padding: 2px; }
   calendar:selected {
-    background-color: #cc575d;
-    color: #ffffff;
     border-radius: 1.5px; }
   calendar.header {
     color: #5c616c;
-    border: none;
-    border-radius: 0; }
-  calendar.button, calendar.button:focus {
-    color: rgba(92, 97, 108, 0.45);
-    border-color: transparent;
-    background-color: transparent;
-    background-image: none; }
-    calendar.button:hover, calendar.button:focus:hover {
+    border: none; }
+  calendar.button {
+    color: rgba(92, 97, 108, 0.45); }
+    calendar.button:hover {
       color: #5c616c; }
-    calendar.button:disabled, calendar.button:focus:disabled {
-      color: rgba(92, 97, 108, 0.55);
-      background-color: transparent;
-      background-image: none; }
+    calendar.button:disabled {
+      color: rgba(92, 97, 108, 0.55); }
   calendar:indeterminate {
     color: alpha(currentColor,0.55); }
   calendar.highlight {
@@ -2626,7 +2606,7 @@ placessidebar row {
   placessidebar row.sidebar-placeholder-row {
     padding: 0 8px;
     min-height: 2px;
-    background-image: linear-gradient(to top, #F08437);
+    background-image: linear-gradient(to bottom, #F08437, #F08437);
     background-clip: content-box; }
   placessidebar row.sidebar-new-bookmark-row {
     color: #cc575d; }
@@ -2656,15 +2636,15 @@ paned > separator {
   -gtk-icon-source: none;
   border-style: none;
   background-color: transparent;
-  background-image: linear-gradient(to top, #dcdfe3);
+  background-image: linear-gradient(to bottom, #dcdfe3, #dcdfe3);
   background-size: 1px 1px; }
   paned > separator:selected {
-    background-image: linear-gradient(to top, #cc575d); }
+    background-image: linear-gradient(to bottom, #cc575d, #cc575d); }
   paned > separator.wide {
     min-width: 5px;
     min-height: 5px;
     background-color: #F5F6F7;
-    background-image: linear-gradient(to top, #dcdfe3), linear-gradient(to top, #dcdfe3);
+    background-image: linear-gradient(to bottom, #dcdfe3, #dcdfe3), linear-gradient(to bottom, #dcdfe3, #dcdfe3);
     background-size: 1px 1px, 1px 1px; }
 
 paned.horizontal > separator {
@@ -2696,107 +2676,44 @@ paned.vertical > separator {
 
 infobar {
   border-style: none; }
+  infobar.info, infobar.question, infobar.warning, infobar.error {
+    background-color: #cc575d;
+    color: #ffffff;
+    caret-color: currentColor; }
+    infobar.info selection, infobar.question selection, infobar.warning selection, infobar.error selection {
+      color: #cc575d;
+      background-color: #ffffff; }
 
-.info,
-.question,
-.warning,
-.error {
-  background-color: #cc575d;
-  color: #ffffff; }
-  .info label:selected:focus, .info label:selected:hover, .info label:selected,
-  .question label:selected:focus,
-  .question label:selected:hover,
-  .question label:selected,
-  .warning label:selected:focus,
-  .warning label:selected:hover,
-  .warning label:selected,
-  .error label:selected:focus,
-  .error label:selected:hover,
-  .error label:selected {
-    color: #cc575d;
-    background-color: #ffffff; }
-
-.selection-mode.primary-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, .info button,
-.question button,
-.warning button,
-.error button, .nautilus-window .floating-bar button {
+.selection-mode.primary-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, infobar.info button, infobar.question button, infobar.warning button, infobar.error button, .nautilus-window .floating-bar button {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.5); }
 
-row:selected button.flat, row:selected button.sidebar-button, .info button.flat, .info button.sidebar-button,
-.question button.flat,
-.question button.sidebar-button,
-.warning button.flat,
-.warning button.sidebar-button,
-.error button.flat,
-.error button.sidebar-button, .nautilus-window .floating-bar button.flat, .nautilus-window .floating-bar button.sidebar-button {
+row:selected button.flat, row:selected button.sidebar-button, infobar.info button.flat, infobar.info button.sidebar-button, infobar.question button.flat, infobar.question button.sidebar-button, infobar.warning button.flat, infobar.warning button.sidebar-button, infobar.error button.flat, infobar.error button.sidebar-button, .nautilus-window .floating-bar button.flat, .nautilus-window .floating-bar button.sidebar-button {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0); }
-  .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, row:selected button.flat:disabled, row:selected button.sidebar-button:disabled, .info button.flat:disabled, .info button.sidebar-button:disabled,
-  .question button.flat:disabled,
-  .question button.sidebar-button:disabled,
-  .warning button.flat:disabled,
-  .warning button.sidebar-button:disabled,
-  .error button.flat:disabled,
-  .error button.sidebar-button:disabled, .nautilus-window .floating-bar button.flat:disabled, .nautilus-window .floating-bar button.sidebar-button:disabled, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled label, row:selected button.sidebar-button:disabled label, .info button.flat:disabled label, .info button.sidebar-button:disabled label,
-  .question button.flat:disabled label,
-  .question button.sidebar-button:disabled label,
-  .warning button.flat:disabled label,
-  .warning button.sidebar-button:disabled label,
-  .error button.flat:disabled label,
-  .error button.sidebar-button:disabled label, .nautilus-window .floating-bar button.flat:disabled label, .nautilus-window .floating-bar button.sidebar-button:disabled label {
+  .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, row:selected button.flat:disabled, row:selected button.sidebar-button:disabled, infobar.info button.flat:disabled, infobar.info button.sidebar-button:disabled, infobar.question button.flat:disabled, infobar.question button.sidebar-button:disabled, infobar.warning button.flat:disabled, infobar.warning button.sidebar-button:disabled, infobar.error button.flat:disabled, infobar.error button.sidebar-button:disabled, .nautilus-window .floating-bar button.flat:disabled, .nautilus-window .floating-bar button.sidebar-button:disabled, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled label, row:selected button.sidebar-button:disabled label, infobar.info button.flat:disabled label, infobar.info button.sidebar-button:disabled label, infobar.question button.flat:disabled label, infobar.question button.sidebar-button:disabled label, infobar.warning button.flat:disabled label, infobar.warning button.sidebar-button:disabled label, infobar.error button.flat:disabled label, infobar.error button.sidebar-button:disabled label, .nautilus-window .floating-bar button.flat:disabled label, .nautilus-window .floating-bar button.sidebar-button:disabled label {
     color: rgba(255, 255, 255, 0.4); }
 
-row:selected button:hover, .info button:hover,
-.question button:hover,
-.warning button:hover,
-.error button:hover, .nautilus-window .floating-bar button:hover {
+row:selected button:hover, infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover, .nautilus-window .floating-bar button:hover {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   background-color: rgba(255, 255, 255, 0.2);
   border-color: rgba(255, 255, 255, 0.8); }
 
-.selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, .info button:active,
-.question button:active,
-.warning button:active,
-.error button:active, .nautilus-window .floating-bar button:active, .selection-mode.primary-toolbar button:hover:active, headerbar.selection-mode button:hover:active, .selection-mode.primary-toolbar button:hover:checked, headerbar.selection-mode button:hover:checked, row:selected button:active:hover, .info button:active:hover,
-.question button:active:hover,
-.warning button:active:hover,
-.error button:active:hover, .nautilus-window .floating-bar button:active:hover, row:selected button:checked, .info button:checked,
-.question button:checked,
-.warning button:checked,
-.error button:checked, .nautilus-window .floating-bar button:checked {
+.selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, .nautilus-window .floating-bar button:active, .selection-mode.primary-toolbar button:hover:active, headerbar.selection-mode button:hover:active, .selection-mode.primary-toolbar button:hover:checked, headerbar.selection-mode button:hover:checked, row:selected button:active:hover, infobar.info button:active:hover, infobar.question button:active:hover, infobar.warning button:active:hover, infobar.error button:active:hover, .nautilus-window .floating-bar button:active:hover, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked, .nautilus-window .floating-bar button:checked {
   color: #cc575d;
-  outline-color: rgba(204, 87, 93, 0.3);
   background-color: #ffffff;
   border-color: #ffffff; }
 
-row:selected button:disabled, .info button:disabled,
-.question button:disabled,
-.warning button:disabled,
-.error button:disabled, .nautilus-window .floating-bar button:disabled {
+row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, .nautilus-window .floating-bar button:disabled {
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.4); }
-  row:selected button:disabled, .info button:disabled,
-  .question button:disabled,
-  .warning button:disabled,
-  .error button:disabled, .nautilus-window .floating-bar button:disabled, row:selected button:disabled label, .info button:disabled label,
-  .question button:disabled label,
-  .warning button:disabled label,
-  .error button:disabled label, .nautilus-window .floating-bar button:disabled label {
+  row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, .nautilus-window .floating-bar button:disabled, row:selected button:disabled label, infobar.info button:disabled label, infobar.question button:disabled label, infobar.warning button:disabled label, infobar.error button:disabled label, .nautilus-window .floating-bar button:disabled label {
     color: rgba(255, 255, 255, 0.5); }
-  .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, row:selected button:disabled:active, .info button:disabled:active,
-  .question button:disabled:active,
-  .warning button:disabled:active,
-  .error button:disabled:active, .nautilus-window .floating-bar button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:checked, .info button:disabled:checked,
-  .question button:disabled:checked,
-  .warning button:disabled:checked,
-  .error button:disabled:checked, .nautilus-window .floating-bar button:disabled:checked {
+  .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, .nautilus-window .floating-bar button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked, .nautilus-window .floating-bar button:disabled:checked {
     color: #cc575d;
     background-color: rgba(255, 255, 255, 0.5);
     border-color: rgba(255, 255, 255, 0.4); }
@@ -2871,12 +2788,10 @@ colorswatch#add-color-button {
   border-style: solid;
   border-width: 1px;
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: #fbfbfc; }
   colorswatch#add-color-button:hover {
     color: #5c616c;
-    outline-color: rgba(92, 97, 108, 0.3);
     border-color: #cfd6e6;
     background-color: white; }
   colorswatch#add-color-button overlay {
@@ -2900,7 +2815,6 @@ colorchooser .popover.osd {
 
 .scale-popup button:hover {
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: white; }
 
@@ -2909,13 +2823,14 @@ popover.background.touch-selection, .csd popover.background.touch-selection {
   font: initial; }
 
 .monospace {
-  font: Monospace; }
+  font-family: Monospace; }
 
 button.circular, button.nautilus-circular-button.image-button,
 button.circular-button {
   padding: 0;
-  min-width: 26px;
-  min-height: 26px;
+  min-width: 16px;
+  min-height: 24px;
+  padding: 2px 6px;
   border-radius: 50%;
   -gtk-outline-radius: 50%; }
   button.circular label, button.nautilus-circular-button.image-button label,
@@ -2993,14 +2908,12 @@ headerbar button.titlebutton,
   headerbar button.titlebutton:hover,
   .titlebar button.titlebutton:hover {
     color: rgba(207, 218, 231, 0.8);
-    outline-color: rgba(207, 218, 231, 0.1);
     border-color: rgba(21, 23, 28, 0.37);
     background-color: rgba(95, 105, 127, 0.37); }
   headerbar button.titlebutton:active, headerbar button.titlebutton:checked,
   .titlebar button.titlebutton:active,
   .titlebar button.titlebutton:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d; }
   headerbar button.titlebutton.close, headerbar button.titlebutton.maximize, headerbar button.titlebutton.minimize,
@@ -3062,7 +2975,7 @@ textview text selection, flowbox flowboxchild:selected, entry selection:focus, e
 modelbutton.flat:active,
 modelbutton.flat:active arrow,
 modelbutton.flat:selected,
-modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
+modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, calendar:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
 .nautilus-window placessidebar.sidebar row.sidebar-row.has-open-popup:selected,
 .nautilus-window placessidebar.sidebar row.sidebar-row:selected,
 .nautilus-window placessidebar.sidebar row.sidebar-row:selected:hover,
@@ -3076,20 +2989,19 @@ modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:
   modelbutton.flat:active,
   modelbutton.flat:active arrow,
   modelbutton.flat:selected,
-  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
+  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, calendar:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
   .nautilus-window placessidebar.sidebar row.sidebar-row.has-open-popup:selected,
   .nautilus-window placessidebar.sidebar row.sidebar-row:selected,
   .nautilus-window placessidebar.sidebar row.sidebar-row:selected:hover,
   .nautilus-window placessidebar.sidebar row.sidebar-row:active:hover {
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3); }
+    color: #ffffff; }
     row:selected label:disabled, label:disabled:selected, .view:disabled:selected, iconview:disabled:selected, iconview:disabled:selected:focus, .view text:disabled:selected, iconview text:disabled:selected,
     textview text:disabled:selected, iconview text selection:disabled:focus, .view text selection:disabled, iconview text selection:disabled,
     textview text selection:disabled, flowbox flowboxchild:disabled:selected, label:disabled selection, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
     modelbutton.flat:disabled:active,
     modelbutton.flat:active arrow:disabled,
     modelbutton.flat:disabled:selected,
-    modelbutton.flat:selected arrow:disabled, treeview.view:disabled:selected:focus, row:disabled:selected, .nemo-window .nemo-window-pane widget.entry:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:active:hover,
+    modelbutton.flat:selected arrow:disabled, treeview.view:disabled:selected:focus, row:disabled:selected, calendar:disabled:selected, .nemo-window .nemo-window-pane widget.entry:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:active:hover,
     .nautilus-window placessidebar.sidebar row.sidebar-row:disabled:selected,
     .nautilus-window placessidebar.sidebar row.sidebar-row:disabled:active:hover {
       color: #e6abae; }
@@ -3098,10 +3010,12 @@ modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:
 terminal-window notebook > header.top > tabs > tab:checked {
   box-shadow: inset 0 -1px #dcdfe3; }
 
-terminal-window notebook > header.top {
+terminal-window notebook > header.top,
+.mate-terminal notebook > header.top {
   padding-top: 3px;
   box-shadow: inset 0 1px #262a33, inset 0 -1px #dcdfe3; }
-  terminal-window notebook > header.top button {
+  terminal-window notebook > header.top button,
+  .mate-terminal notebook > header.top button {
     padding: 0;
     min-width: 24px;
     min-height: 24px; }
@@ -3110,7 +3024,7 @@ terminal-window notebook > header.top {
   border-radius: 2px; }
 
 .nautilus-desktop.nautilus-canvas-item, .nemo-desktop.nemo-canvas-item, .caja-desktop {
-  color: #ffffff;
+  color: white;
   text-shadow: 1px 1px rgba(0, 0, 0, 0.6); }
   .nautilus-desktop.nautilus-canvas-item:active, .nemo-desktop.nemo-canvas-item:active, .caja-desktop:active {
     color: #5c616c; }
@@ -3153,12 +3067,10 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
 @keyframes needs_attention_keyframes {
   0% {
     color: rgba(207, 218, 231, 0.8);
-    outline-color: rgba(207, 218, 231, 0.1);
     border-color: rgba(21, 23, 28, 0.37);
     background-color: rgba(95, 105, 127, 0.37); }
   100% {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d; } }
 
@@ -3168,6 +3080,17 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
 .nautilus-operations-button-needs-attention-multiple {
   animation: needs_attention_keyframes 3s ease-in-out;
   animation-iteration-count: 3; }
+
+.conflict-row.activatable, .conflict-row.activatable:active {
+  color: white;
+  background-color: #FC4138; }
+
+.conflict-row.activatable:hover {
+  background-color: #fd716a; }
+
+.conflict-row.activatable:selected {
+  color: #ffffff;
+  background-color: #cc575d; }
 
 .nemo-window .nemo-places-sidebar.frame {
   border-width: 0; }
@@ -3180,12 +3103,10 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
   border-radius: 3px;
   color: #5c616c;
   border-color: #cc575d;
-  background-color: #ffffff;
-  background-image: linear-gradient(to bottom, #ffffff); }
+  background-color: #ffffff; }
 
 .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button {
   color: rgba(207, 218, 231, 0.8);
-  outline-color: rgba(207, 218, 231, 0.1);
   border-color: rgba(21, 23, 28, 0.37);
   background-color: rgba(95, 105, 127, 0.37); }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:not(:last-child):not(:only-child) {
@@ -3194,7 +3115,6 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
     background-color: rgba(134, 144, 165, 0.37); }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:active, .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d; }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:disabled {
@@ -3288,6 +3208,27 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
   margin: 2px;
   padding: 2px; }
 
+.gedit-map-frame border {
+  border-color: rgba(0, 0, 0, 0.3);
+  border-width: 0; }
+  .gedit-map-frame border:dir(ltr) {
+    border-left-width: 1px; }
+  .gedit-map-frame border:dir(rtl) {
+    border-right-width: 1px; }
+
+.pluma-window statusbar frame > border {
+  border: none; }
+
+.pluma-window notebook > stack scrolledwindow {
+  border-width: 0 0 1px 0; }
+
+#pluma-status-combo-button {
+  min-height: 0;
+  padding: 0;
+  border-top: none;
+  border-bottom: none;
+  border-radius: 0; }
+
 .gb-search-entry-occurrences-tag {
   background: none; }
 
@@ -3316,6 +3257,8 @@ pillbox {
   color: #ffffff;
   background-color: #cc575d;
   border-radius: 3px; }
+  pillbox:disabled label {
+    color: rgba(255, 255, 255, 0.5); }
 
 docktabstrip {
   padding: 0 6px;
@@ -3348,6 +3291,62 @@ dockoverlayedge {
   dockoverlayedge.left-edge tab:checked,
   dockoverlayedge.right-edge tab:checked {
     border-width: 1px 0; }
+
+popover.messagepopover.background {
+  padding: 0; }
+
+popover.messagepopover .popover-content-area {
+  margin: 16px; }
+
+popover.messagepopover .popover-action-area {
+  margin: 8px; }
+  popover.messagepopover .popover-action-area button:not(:first-child):not(:last-child) {
+    margin: 0 4px; }
+
+popover.popover-selector {
+  padding: 0; }
+  popover.popover-selector list row {
+    padding: 5px 0; }
+  popover.popover-selector list row image {
+    margin-left: 3px;
+    margin-right: 10px; }
+
+entry.search.preferences-search {
+  border: none;
+  border-right: 1px solid #dcdfe3;
+  border-bottom: 1px solid #dcdfe3;
+  border-radius: 0; }
+
+preferences stacksidebar.sidebar list {
+  background-image: linear-gradient(to bottom, #ffffff, #ffffff); }
+
+preferences stacksidebar.sidebar list separator {
+  background-color: transparent; }
+
+devhelppanel entry:focus,
+symboltreepanel entry:focus {
+  border-color: #dcdfe3; }
+
+button.run-arrow-button {
+  min-width: 12px; }
+
+omnibar.linked > entry:not(:only-child) {
+  border-style: solid;
+  border-radius: 3px;
+  margin-left: 1px;
+  margin-right: 1px; }
+
+gstyleslidein #scale_box button.toggle:checked,
+gstyleslidein #strings_controls button.toggle:checked,
+gstyleslidein #palette_controls button.toggle:checked,
+gstyleslidein #components_controls button.toggle:checked {
+  color: #5c616c; }
+
+configurationview entry.flat {
+  background: none; }
+
+configurationview list {
+  border-width: 0; }
 
 .documents-scrolledwin.frame {
   border-width: 0; }
@@ -3396,46 +3395,119 @@ button.documents-favorite:active:hover {
   opacity: 0.0;
   transition: opacity 0.2s ease-out; }
 
+.tweak-categories,
+.tweak-category:not(:selected):not(:hover) {
+  background-image: linear-gradient(to bottom, #ffffff, #ffffff); }
+
 .tr-workarea undershoot,
 .tr-workarea overshoot {
   border-color: transparent; }
 
-.gnome-panel-menu-bar, .gnome-panel-menu-bar menubar,
-.mate-panel-menu-bar,
-.mate-panel-menu-bar menubar {
-  background-color: rgba(43, 46, 55, 0.95); }
+.atril-window .primary-toolbar toolbar, .atril-window .primary-toolbar .inline-toolbar {
+  background: none; }
 
-.gnome-panel-menu-bar menubar,
-.gnome-panel-menu-bar #PanelApplet label,
-.gnome-panel-menu-bar #PanelApplet image,
+#gf-bubble, #gf-bubble.solid,
+#gf-osd-window,
+#gf-osd-window.solid,
+#gf-input-source-popup,
+#gf-input-source-popup.solid,
+#gf-candidate-popup,
+#gf-candidate-popup.solid {
+  color: #cfd5de;
+  background-color: rgba(53, 57, 69, 0.95);
+  border: 1px solid rgba(35, 38, 46, 0.95);
+  border-radius: 2px; }
+
+#gf-bubble levelbar block.low, #gf-bubble levelbar block.high, #gf-bubble levelbar block.full,
+#gf-osd-window levelbar block.low,
+#gf-osd-window levelbar block.high,
+#gf-osd-window levelbar block.full,
+#gf-input-source-popup levelbar block.low,
+#gf-input-source-popup levelbar block.high,
+#gf-input-source-popup levelbar block.full,
+#gf-candidate-popup levelbar block.low,
+#gf-candidate-popup levelbar block.high,
+#gf-candidate-popup levelbar block.full {
+  background-color: #cc575d;
+  border-color: #cc575d; }
+
+#gf-bubble levelbar block.empty,
+#gf-osd-window levelbar block.empty,
+#gf-input-source-popup levelbar block.empty,
+#gf-candidate-popup levelbar block.empty {
+  background-color: rgba(42, 45, 55, 0.95); }
+
+#gf-bubble levelbar trough,
+#gf-osd-window levelbar trough,
+#gf-input-source-popup levelbar trough,
+#gf-candidate-popup levelbar trough {
+  background: none; }
+
+#gf-input-source {
+  min-height: 32px;
+  min-width: 40px; }
+  #gf-input-source:selected {
+    color: #ffffff;
+    background-color: #cc575d;
+    border-radius: 2px; }
+
+gf-candidate-box label {
+  padding: 3px; }
+
+gf-candidate-box:hover, gf-candidate-box:selected {
+  color: #ffffff;
+  background-color: #cc575d;
+  border-radius: 2px; }
+
+MsdOsdWindow.background.osd {
+  border-radius: 2px;
+  border: 1px solid rgba(35, 38, 46, 0.95); }
+  MsdOsdWindow.background.osd .progressbar {
+    background-color: #cc575d;
+    border: none;
+    border-color: red;
+    border-radius: 5px; }
+  MsdOsdWindow.background.osd .trough {
+    background-color: rgba(42, 45, 55, 0.95);
+    border: none;
+    border-radius: 5px; }
+
+.mate-panel-menu-bar, .mate-panel-menu-bar menubar,
+panel-toplevel.background,
+panel-toplevel.background menubar {
+  background-color: #2b2e37; }
+
 .mate-panel-menu-bar menubar,
 .mate-panel-menu-bar #PanelApplet label,
-.mate-panel-menu-bar #PanelApplet image {
+.mate-panel-menu-bar #PanelApplet image,
+panel-toplevel.background menubar,
+panel-toplevel.background #PanelApplet label,
+panel-toplevel.background #PanelApplet image {
   color: #BAC3CF; }
 
-.gnome-panel-menu-bar button label, .gnome-panel-menu-bar button image,
-.gnome-panel-menu-bar #tasklist-button label,
-.gnome-panel-menu-bar #tasklist-button image,
-.mate-panel-menu-bar button label,
-.mate-panel-menu-bar button image,
+.mate-panel-menu-bar button label, .mate-panel-menu-bar button image,
 .mate-panel-menu-bar #tasklist-button label,
-.mate-panel-menu-bar #tasklist-button image {
+.mate-panel-menu-bar #tasklist-button image,
+panel-toplevel.background button label,
+panel-toplevel.background button image,
+panel-toplevel.background #tasklist-button label,
+panel-toplevel.background #tasklist-button image {
   color: inherit; }
 
-.gnome-panel-menu-bar .wnck-pager,
-.mate-panel-menu-bar .wnck-pager {
+.mate-panel-menu-bar .wnck-pager,
+panel-toplevel.background .wnck-pager {
   color: #5d6268;
   background-color: rgba(20, 22, 27, 0.95); }
-  .gnome-panel-menu-bar .wnck-pager:hover,
-  .mate-panel-menu-bar .wnck-pager:hover {
+  .mate-panel-menu-bar .wnck-pager:hover,
+  panel-toplevel.background .wnck-pager:hover {
     background-color: rgba(54, 58, 70, 0.95); }
-  .gnome-panel-menu-bar .wnck-pager:selected,
-  .mate-panel-menu-bar .wnck-pager:selected {
+  .mate-panel-menu-bar .wnck-pager:selected,
+  panel-toplevel.background .wnck-pager:selected {
     color: #e4a5a8;
     background-color: #cc575d; }
 
-.gnome-panel-menu-bar na-tray-applet,
-.mate-panel-menu-bar na-tray-applet {
+.mate-panel-menu-bar na-tray-applet,
+panel-toplevel.background na-tray-applet {
   -NaTrayApplet-icon-padding: 0;
   -NaTrayApplet-icon-size: 16px; }
 
@@ -3453,26 +3525,32 @@ button.documents-favorite:active:hover {
     color: #d8dde4;
     background-color: rgba(0, 0, 0, 0.17); }
   #tasklist-button:checked {
-    color: #ffffff;
+    color: white;
     background-color: rgba(0, 0, 0, 0.25);
     box-shadow: inset 0 -2px #cc575d; }
 
-.gnome-panel-menu-bar button:not(#tasklist-button),
-.mate-panel-menu-bar button:not(#tasklist-button), .xfce4-panel.panel button.flat, .xfce4-panel.panel button.sidebar-button {
+.mate-panel-menu-bar button:not(#tasklist-button),
+panel-toplevel.background button:not(#tasklist-button), .xfce4-panel.panel button.flat, .xfce4-panel.panel button.sidebar-button {
   color: #BAC3CF;
   border-radius: 0;
   border: none;
   background-color: rgba(43, 46, 55, 0); }
-  .gnome-panel-menu-bar button:hover:not(#tasklist-button),
-  .mate-panel-menu-bar button:hover:not(#tasklist-button), .xfce4-panel.panel button.flat:hover, .xfce4-panel.panel button.sidebar-button:hover {
+  .mate-panel-menu-bar button:hover:not(#tasklist-button),
+  panel-toplevel.background button:hover:not(#tasklist-button), .xfce4-panel.panel button.flat:hover, .xfce4-panel.panel button.sidebar-button:hover {
     border: none;
     background-color: rgba(65, 70, 84, 0.95); }
-  .gnome-panel-menu-bar button:active:not(#tasklist-button),
-  .mate-panel-menu-bar button:active:not(#tasklist-button), .xfce4-panel.panel button.flat:active, .xfce4-panel.panel button.sidebar-button:active, .gnome-panel-menu-bar button:checked:not(#tasklist-button),
-  .mate-panel-menu-bar button:checked:not(#tasklist-button), .xfce4-panel.panel button.flat:checked, .xfce4-panel.panel button.sidebar-button:checked {
+  .mate-panel-menu-bar button:active:not(#tasklist-button),
+  panel-toplevel.background button:active:not(#tasklist-button), .xfce4-panel.panel button.flat:active, .xfce4-panel.panel button.sidebar-button:active, .mate-panel-menu-bar button:checked:not(#tasklist-button),
+  panel-toplevel.background button:checked:not(#tasklist-button), .xfce4-panel.panel button.flat:checked, .xfce4-panel.panel button.sidebar-button:checked {
     color: #ffffff;
     border: none;
     background-color: #cc575d; }
+    .mate-panel-menu-bar button:active:not(#tasklist-button) label,
+    panel-toplevel.background button:active:not(#tasklist-button) label, .xfce4-panel.panel button.flat:active label, .xfce4-panel.panel button.sidebar-button:active label, .mate-panel-menu-bar button:active:not(#tasklist-button) image,
+    panel-toplevel.background button:active:not(#tasklist-button) image, .xfce4-panel.panel button.flat:active image, .xfce4-panel.panel button.sidebar-button:active image, .mate-panel-menu-bar button:checked:not(#tasklist-button) label,
+    panel-toplevel.background button:checked:not(#tasklist-button) label, .xfce4-panel.panel button.flat:checked label, .xfce4-panel.panel button.sidebar-button:checked label, .mate-panel-menu-bar button:checked:not(#tasklist-button) image,
+    panel-toplevel.background button:checked:not(#tasklist-button) image, .xfce4-panel.panel button.flat:checked image, .xfce4-panel.panel button.sidebar-button:checked image {
+      color: inherit; }
 
 .nautilus-window .floating-bar {
   padding: 1px;
@@ -3494,17 +3572,17 @@ button.documents-favorite:active:hover {
   padding-right: 4px;
   color: rgba(207, 218, 231, 0.8);
   border-color: rgba(21, 23, 28, 0.37);
-  background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.37));
-  background-color: transparent; }
+  background-color: rgba(95, 105, 127, 0.37); }
   .marlin-pathbar.pathbar image, .marlin-pathbar.pathbar image:hover {
     color: inherit; }
   .marlin-pathbar.pathbar:focus {
     color: #ffffff;
     border-color: transparent;
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
   .marlin-pathbar.pathbar:disabled {
     color: rgba(207, 218, 231, 0.35);
-    background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.22)); }
+    border-color: rgba(21, 23, 28, 0.37);
+    background-color: rgba(95, 105, 127, 0.22); }
   .marlin-pathbar.pathbar:active, .marlin-pathbar.pathbar:checked {
     color: #cc575d; }
 
@@ -3512,7 +3590,7 @@ button.documents-favorite:active:hover {
   border: 1px solid rgba(0, 0, 0, 0.35);
   border-radius: 3px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  background-image: linear-gradient(to bottom, white);
+  background-image: linear-gradient(to bottom, white, white);
   background-color: transparent; }
   .gala-notification .title, .gala-notification .label {
     color: #5c616c; }
@@ -3579,24 +3657,25 @@ UnityDecoration {
   -UnityDecoration-title-indent: 10px;
   -UnityDecoration-title-fade: 35px;
   -UnityDecoration-title-alignment: 0.0; }
-  UnityDecoration.top {
+  UnityDecoration .top {
     border: 1px solid rgba(32, 35, 43, 0.97);
     border-bottom-width: 0;
     border-radius: 4px 4px 0 0;
     padding: 1px 6px 0 6px;
-    background-image: linear-gradient(to bottom, #2f343f);
+    background-image: linear-gradient(to bottom, #2f343f, #2f343f);
     color: rgba(207, 218, 231, 0.8);
     box-shadow: inset 0 1px rgba(54, 59, 72, 0.97); }
-    UnityDecoration.top:backdrop {
+    UnityDecoration .top:backdrop {
       border-bottom-width: 0;
       color: rgba(207, 218, 231, 0.5); }
-  UnityDecoration.left, UnityDecoration.right, UnityDecoration.bottom, UnityDecoration.left:backdrop, UnityDecoration.right:backdrop, UnityDecoration.bottom:backdrop {
+  UnityDecoration .left, UnityDecoration .right, UnityDecoration .bottom,
+  UnityDecoration .left:backdrop, UnityDecoration .right:backdrop, UnityDecoration .bottom:backdrop {
     background-color: transparent;
-    background-image: linear-gradient(to bottom, rgba(32, 35, 43, 0.97)); }
+    background-image: linear-gradient(to bottom, rgba(32, 35, 43, 0.97), rgba(32, 35, 43, 0.97)); }
 
 UnityPanelWidget,
 .unity-panel {
-  background-image: linear-gradient(to bottom, #2f343f);
+  background-image: linear-gradient(to bottom, #2f343f, #2f343f);
   color: #f6f7f9;
   box-shadow: none; }
   UnityPanelWidget:backdrop,
@@ -3607,7 +3686,7 @@ UnityPanelWidget,
 .unity-panel.menubar .menuitem *:hover {
   border-radius: 0;
   color: #ffffff;
-  background-image: linear-gradient(to bottom, #cc575d);
+  background-image: linear-gradient(to bottom, #cc575d, #cc575d);
   border-bottom: none; }
 
 .lightdm.menu {
@@ -3800,7 +3879,7 @@ GraniteWidgetsWelcome {
 
 GraniteWidgetsWelcome label {
   color: #a9acb2;
-  font: open sans 11;
+  font-size: 11px;
   text-shadow: none; }
 
 GraniteWidgetsWelcome .h1,
@@ -3820,7 +3899,7 @@ GraniteWidgetsPopOver {
   margin: 0; }
 
 .popover_bg {
-  background-image: linear-gradient(to bottom, #ffffff);
+  background-image: linear-gradient(to bottom, #ffffff, #ffffff);
   border: 1px solid rgba(0, 0, 0, 0.3); }
 
 GraniteWidgetsPopOver .sidebar.view, GraniteWidgetsPopOver iconview.sidebar,
@@ -3831,13 +3910,13 @@ GraniteWidgetsXsEntry entry {
   padding: 4px; }
 
 .h1 {
-  font: open sans 24px; }
+  font-size: 24px; }
 
 .h2 {
-  font: open sans light 18px; }
+  font-size: 18px; }
 
 .h3 {
-  font: open sans 11px; }
+  font-size: 11px; }
 
 .h4,
 .category-label {
@@ -3854,24 +3933,25 @@ GtkListBox .h4 {
 #panel_window {
   background-color: rgba(43, 46, 55, 0.95);
   color: #BAC3CF;
-  font: bold;
+  font-weight: bold;
   box-shadow: inset 0 -1px rgba(27, 29, 35, 0.95); }
-  #panel_window menubar,
-  #panel_window menubar > menuitem {
-    background-color: transparent;
-    color: #BAC3CF;
-    font: bold; }
+  #panel_window menubar {
+    padding-left: 5px; }
+    #panel_window menubar, #panel_window menubar > menuitem {
+      background-color: transparent;
+      color: #BAC3CF;
+      font-weight: bold; }
   #panel_window menubar menuitem:disabled {
     color: rgba(186, 195, 207, 0.5); }
     #panel_window menubar menuitem:disabled label {
       color: inherit; }
   #panel_window menubar menu > menuitem {
-    font: normal; }
+    font-weight: normal; }
 
 #login_window,
 #shutdown_dialog,
 #restart_dialog {
-  font: normal;
+  font-weight: normal;
   border-style: none;
   background-color: transparent;
   color: #5c616c; }
@@ -3886,17 +3966,14 @@ GtkListBox .h4 {
 
 #content_frame button {
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: #fbfbfc; }
   #content_frame button:hover {
     color: #5c616c;
-    outline-color: rgba(92, 97, 108, 0.3);
     border-color: #cfd6e6;
     background-color: white; }
   #content_frame button:active, #content_frame button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d; }
   #content_frame button:disabled {
@@ -3918,17 +3995,14 @@ GtkListBox .h4 {
 
 #buttonbox_frame button {
   color: #BAC3CF;
-  outline-color: rgba(186, 195, 207, 0.3);
   border-color: rgba(26, 28, 34, 0.35);
   background-color: rgba(102, 109, 132, 0.35); }
   #buttonbox_frame button:hover {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: rgba(119, 127, 151, 0.45); }
   #buttonbox_frame button:active, #buttonbox_frame button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: #cc575d; }
   #buttonbox_frame button:disabled {
@@ -3938,9 +4012,9 @@ GtkListBox .h4 {
 
 #login_window #user_combobox {
   color: #5c616c;
-  font: 13px; }
+  font-size: 13px; }
   #login_window #user_combobox menu {
-    font: normal; }
+    font-weight: normal; }
 
 #user_image {
   padding: 3px;
@@ -3948,55 +4022,49 @@ GtkListBox .h4 {
 
 #shutdown_button.button {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
+  color: green;
   background-color: #F04A50;
   border-color: #F04A50; }
   #shutdown_button.button:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #f4797e;
     border-color: #f4797e; }
   #shutdown_button.button:active, #shutdown_button.button:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #ec1b22;
     border-color: #ec1b22; }
 
 #restart_button.button {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
-  background-color: #be3941;
-  border-color: #be3941; }
+  color: green;
+  background-color: #BE3941;
+  border-color: #BE3941; }
   #restart_button.button:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #ce5c63;
     border-color: #ce5c63; }
   #restart_button.button:active, #restart_button.button:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #972d34;
     border-color: #972d34; }
 
 #greeter_infobar {
   border-bottom-width: 0;
-  font: bold; }
+  font-weight: bold; }
 
 .nautilus-window paned > separator {
-  background-image: linear-gradient(to top, rgba(53, 57, 69, 0.95)); }
+  background-image: linear-gradient(to bottom, rgba(53, 57, 69, 0.95), rgba(53, 57, 69, 0.95)); }
   .nautilus-window paned > separator:dir(ltr) {
     margin-left: -1px; }
   .nautilus-window paned > separator:dir(rtl) {
     margin-right: -1px; }
 
 filechooser paned > separator {
-  background-image: linear-gradient(to top, rgba(53, 57, 69, 0.95)); }
+  background-image: linear-gradient(to bottom, rgba(53, 57, 69, 0.95), rgba(53, 57, 69, 0.95)); }
 
 filechooser.csd.background, filechooser placessidebar list,
 .nautilus-window.csd.background,
@@ -4034,13 +4102,11 @@ filechooser placessidebar.sidebar,
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:hover,
       .nautilus-window placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:hover {
         color: #BAC3CF;
-        outline-color: rgba(186, 195, 207, 0.3);
         border-color: rgba(26, 28, 34, 0.35);
         background-color: rgba(119, 127, 151, 0.45); }
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:active,
       .nautilus-window placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:active {
         color: #ffffff;
-        outline-color: rgba(255, 255, 255, 0.3);
         border-color: #cc575d;
         background-color: #cc575d; }
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:not(:hover):not(:active) > image,
@@ -4116,6 +4182,12 @@ filechooser actionbar {
 .gedit-bottom-panel-paned {
   background-color: #ffffff; }
 
+.gedit-side-panel-paned > separator {
+  background-image: linear-gradient(to bottom, rgba(53, 57, 69, 0.95), rgba(53, 57, 69, 0.95)); }
+
+.gedit-bottom-panel-paned > separator {
+  background-image: linear-gradient(to bottom, #dcdfe3, #dcdfe3); }
+
 .gedit-document-panel {
   background-color: rgba(53, 57, 69, 0.95); }
   .maximized .gedit-document-panel {
@@ -4138,17 +4210,14 @@ filechooser actionbar {
 
 filechooser actionbar button {
   color: #BAC3CF;
-  outline-color: rgba(186, 195, 207, 0.3);
   border-color: rgba(26, 28, 34, 0.35);
   background-color: rgba(102, 109, 132, 0.35); }
   .caja-side-pane > box button:hover:not(:active), filechooser actionbar button:hover {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: rgba(119, 127, 151, 0.45); }
   filechooser actionbar button:active, filechooser actionbar button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: #cc575d; }
   filechooser actionbar button:disabled {
@@ -4159,17 +4228,16 @@ filechooser actionbar button {
 filechooser actionbar entry {
   color: #BAC3CF;
   border-color: rgba(26, 28, 34, 0.35);
-  background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.35));
-  background-color: transparent; }
+  background-color: rgba(102, 109, 132, 0.35); }
   filechooser actionbar entry image, filechooser actionbar entry image:hover {
     color: inherit; }
   filechooser actionbar entry:focus {
     color: #ffffff;
     border-color: rgba(26, 28, 34, 0.35);
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
   filechooser actionbar entry:disabled {
     color: rgba(186, 195, 207, 0.55);
-    background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.2)); }
+    background-color: rgba(102, 109, 132, 0.2); }
 
 filechooser placessidebar.sidebar scrollbar,
 .nautilus-window placessidebar.sidebar scrollbar, .nemo-window .sidebar scrollbar, .caja-side-pane scrollbar {

--- a/common/gtk-3.0/3.20/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.20/gtk-solid-dark.css
@@ -4,13 +4,11 @@
   -GtkTextView-error-underline-color: #FC4138;
   -GtkScrolledWindow-scrollbar-spacing: 0;
   -GtkToolItemGroup-expander-size: 11;
-  -GtkTreeView-expander-size: 11;
-  -GtkTreeView-horizontal-separator: 4;
   -GtkWidget-text-handle-width: 20;
   -GtkWidget-text-handle-height: 20;
   -GtkDialog-button-spacing: 4;
   -GtkDialog-action-area-border: 0;
-  outline-color: rgba(211, 218, 227, 0.3);
+  outline-color: alpha(currentColor,0.3);
   outline-style: dashed;
   outline-offset: -3px;
   outline-width: 1px;
@@ -107,7 +105,6 @@ popover.background.magnifier, .csd popover.background.osd, .csd popover.backgrou
   border: none;
   background-color: #353945;
   background-clip: padding-box;
-  outline-color: rgba(186, 195, 207, 0.3);
   box-shadow: none; }
 
 @keyframes spin {
@@ -133,8 +130,7 @@ entry {
   transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
   color: #D3DAE3;
   border-color: #2b2e39;
-  background-color: #404552;
-  background-image: linear-gradient(to bottom, #404552); }
+  background-color: #404552; }
   entry.search {
     border-radius: 20px; }
   entry image {
@@ -156,51 +152,49 @@ entry {
     color: #D3DAE3;
     border-color: #2b2e39;
     background-color: #404552;
-    background-image: linear-gradient(to bottom, #404552);
     box-shadow: inset 1px 0 #cc575d, inset -1px 0 #cc575d, inset 0 1px #cc575d, inset 0 -1px #cc575d; }
   entry:disabled {
     color: rgba(211, 218, 227, 0.45);
     border-color: rgba(43, 46, 57, 0.55);
-    background-color: rgba(64, 69, 82, 0.55);
-    background-image: linear-gradient(to bottom, rgba(64, 69, 82, 0.55)); }
+    background-color: rgba(64, 69, 82, 0.55); }
   entry.warning {
-    color: #ffffff;
+    color: white;
     border-color: #2b2e39;
-    background-image: linear-gradient(to bottom, #ab6441); }
+    background-color: #ab6441; }
     entry.warning image {
-      color: #ffffff; }
+      color: white; }
     entry.warning:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #F27835);
+      color: white;
+      background-color: #F27835;
       box-shadow: none; }
     entry.warning selection, entry.warning selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #F27835; }
   entry.error {
-    color: #ffffff;
+    color: white;
     border-color: #2b2e39;
-    background-image: linear-gradient(to bottom, #b14342); }
+    background-color: #b14342; }
     entry.error image {
-      color: #ffffff; }
+      color: white; }
     entry.error:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138);
+      color: white;
+      background-color: #FC4138;
       box-shadow: none; }
     entry.error selection, entry.error selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
   entry.search-missing {
-    color: #ffffff;
+    color: white;
     border-color: #2b2e39;
-    background-image: linear-gradient(to bottom, #b14342); }
+    background-color: #b14342; }
     entry.search-missing image {
-      color: #ffffff; }
+      color: white; }
     entry.search-missing:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138);
+      color: white;
+      background-color: #FC4138;
       box-shadow: none; }
     entry.search-missing selection, entry.search-missing selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
   entry:drop(active):focus, entry:drop(active) {
     border-color: #F08437;
@@ -208,17 +202,16 @@ entry {
   .osd entry {
     color: #BAC3CF;
     border-color: rgba(26, 28, 34, 0.4);
-    background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.4));
-    background-color: transparent; }
+    background-color: rgba(102, 109, 132, 0.4); }
     .osd entry image, .osd entry image:hover {
       color: inherit; }
     .osd entry:focus {
       color: #ffffff;
       border-color: rgba(26, 28, 34, 0.4);
-      background-image: linear-gradient(to bottom, #cc575d); }
+      background-color: #cc575d; }
     .osd entry:disabled {
       color: rgba(186, 195, 207, 0.55);
-      background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.25)); }
+      background-color: rgba(102, 109, 132, 0.25); }
     .osd entry selection:focus, .osd entry selection {
       color: #cc575d;
       background-color: #ffffff; }
@@ -253,7 +246,6 @@ button {
   border-radius: 3px;
   padding: 2px 6px;
   color: #D3DAE3;
-  outline-color: rgba(211, 218, 227, 0.3);
   border-color: #2b2e39;
   background-color: #444a58; }
   button separator {
@@ -270,17 +262,18 @@ button {
         transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   button:hover {
     color: #D3DAE3;
-    outline-color: rgba(211, 218, 227, 0.3);
     border-color: #2b2e39;
     background-color: #505666;
     -gtk-icon-effect: highlight; }
   button:active, button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #2b2e39;
     background-color: #cc575d;
     background-clip: padding-box;
     transition-duration: 50ms; }
+    button:active:not(:disabled) label:disabled, button:checked:not(:disabled) label:disabled {
+      color: inherit;
+      opacity: 0.6; }
   button:active {
     color: #D3DAE3; }
   button:active:hover, button:checked {
@@ -328,7 +321,6 @@ button {
     box-shadow: none; }
   button.osd {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     background-color: #353945;
     border-color: #23262e; }
     button.osd.image-button {
@@ -339,7 +331,6 @@ button {
       color: #cc575d; }
     button.osd:active, button.osd:checked {
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.4);
       background-color: #cc575d; }
     button.osd:disabled {
@@ -348,18 +339,15 @@ button {
       background-color: rgba(102, 109, 132, 0.25); }
   .osd button {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: rgba(102, 109, 132, 0.4); }
     .osd button:hover {
       color: #BAC3CF;
-      outline-color: rgba(186, 195, 207, 0.3);
       border-color: rgba(26, 28, 34, 0.4);
       background-color: rgba(119, 127, 151, 0.5); }
     .osd button:active, .osd button:checked {
       background-clip: padding-box;
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.4);
       background-color: #cc575d; }
     .osd button:disabled {
@@ -373,7 +361,6 @@ button {
       box-shadow: none; }
       .osd button.flat:hover, .osd button.sidebar-button:hover {
         color: #BAC3CF;
-        outline-color: rgba(186, 195, 207, 0.3);
         border-color: rgba(26, 28, 34, 0.4);
         background-color: rgba(119, 127, 151, 0.5); }
       .osd button.flat:disabled, .osd button.sidebar-button:disabled {
@@ -383,7 +370,6 @@ button {
         background-image: none; }
       .osd button.flat:active, .osd button.sidebar-button:active, .osd button.flat:checked, .osd button.sidebar-button:checked {
         color: #ffffff;
-        outline-color: rgba(255, 255, 255, 0.3);
         border-color: rgba(26, 28, 34, 0.4);
         background-color: #cc575d; }
   .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active):not(:only-child),
@@ -391,26 +377,22 @@ button {
     box-shadow: none; }
   button.suggested-action {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
-    background-color: #be3941;
-    border-color: #be3941; }
+    color: white;
+    background-color: #BE3941;
+    border-color: #BE3941; }
     button.suggested-action.flat, button.suggested-action.sidebar-button {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
-      color: #be3941;
-      outline-color: rgba(190, 57, 65, 0.3); }
+      color: #BE3941; }
     button.suggested-action:hover {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #ce5c63;
       border-color: #ce5c63; }
     button.suggested-action:active, button.suggested-action:checked {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #972d34;
       border-color: #972d34; }
     button.suggested-action.flat:disabled, button.suggested-action.sidebar-button:disabled {
@@ -425,26 +407,22 @@ button {
         color: rgba(211, 218, 227, 0.45); }
   button.destructive-action {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #F04A50;
     border-color: #F04A50; }
     button.destructive-action.flat, button.destructive-action.sidebar-button {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
-      color: #F04A50;
-      outline-color: rgba(240, 74, 80, 0.3); }
+      color: #F04A50; }
     button.destructive-action:hover {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #f4797e;
       border-color: #f4797e; }
     button.destructive-action:active, button.destructive-action:checked {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #ec1b22;
       border-color: #ec1b22; }
     button.destructive-action.flat:disabled, button.destructive-action.sidebar-button:disabled {
@@ -484,23 +462,22 @@ button {
     background-position: right 3px, right 2px; }
     .stack-switcher > button.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > image:dir(rtl), button stacksidebar row.needs-attention > label:dir(rtl), stacksidebar button row.needs-attention > label:dir(rtl) {
       background-position: left 3px, left 2px; }
+  button.font separator, button.file separator {
+    background-color: transparent; }
   .inline-toolbar button, .inline-toolbar button:backdrop {
     border-radius: 2px;
     border-width: 1px; }
 
 .inline-toolbar toolbutton > button {
   color: #D3DAE3;
-  outline-color: rgba(211, 218, 227, 0.3);
   border-color: #2b2e39;
   background-color: #444a58; }
   .inline-toolbar toolbutton > button:hover {
     color: #D3DAE3;
-    outline-color: rgba(211, 218, 227, 0.3);
     border-color: #2b2e39;
     background-color: #505666; }
   .inline-toolbar toolbutton > button:active, .inline-toolbar toolbutton > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #2b2e39;
     background-color: #cc575d; }
   .inline-toolbar toolbutton > button:disabled {
@@ -577,12 +554,23 @@ button {
 .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
   box-shadow: inset 1px 0 #2b2e39; }
 
-.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
+  box-shadow: inset 1px 0 rgba(43, 46, 57, 0.5); }
+
 .linked:not(.vertical):not(.path-bar) > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
-.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child) {
+.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:disabled,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked:not(.vertical):not(.path-bar) > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child) {
   box-shadow: none; }
 
 .linked:not(.vertical).path-bar > button + button {
@@ -659,12 +647,23 @@ button {
 .linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
   box-shadow: inset 0 1px #2b2e39; }
 
-.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
+  box-shadow: inset 0 1px rgba(43, 46, 57, 0.5); }
+
 .linked.vertical > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
-.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child) {
+.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:disabled,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked.vertical > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child) {
   box-shadow: none; }
 
 toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat, toolbar.inline-toolbar toolbutton > button.sidebar-button, .inline-toolbar toolbutton > button.sidebar-button, .linked:not(.vertical) > entry,
@@ -710,7 +709,7 @@ toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > bu
   border-style: solid; }
 
 menuitem.button.flat,
-modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover, .app-notification button.flat, .app-notification button.sidebar-button, .app-notification button.flat:disabled, .app-notification button.sidebar-button:disabled {
+modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover, .app-notification button.flat, .app-notification button.sidebar-button, .app-notification button.flat:disabled, .app-notification button.sidebar-button:disabled, calendar.button {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
@@ -761,16 +760,7 @@ modelbutton.flat arrow.right {
     color: #e4a5a8; }
     *:selected *:link:active, *:selected button:active:link, *:selected button:active:visited {
       color: #f5dddf; }
-  .info *:link, .info button:link, .info button:visited,
-  .question *:link,
-  .question button:link,
-  .question button:visited,
-  .warning *:link,
-  .warning button:link,
-  .warning button:visited,
-  .error *:link,
-  .error button:link,
-  .error button:visited, *:link:selected, button:selected:link, button:selected:visited, headerbar.selection-mode .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link,
+  infobar.info *:link, infobar.info button:link, infobar.info button:visited, infobar.question *:link, infobar.question button:link, infobar.question button:visited, infobar.warning *:link, infobar.warning button:link, infobar.warning button:visited, infobar.error *:link, infobar.error button:link, infobar.error button:visited, *:link:selected, button:selected:link, button:selected:visited, headerbar.selection-mode .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link,
   *:selected *:link,
   *:selected button:link,
   *:selected button:visited {
@@ -801,6 +791,10 @@ spinbutton:not(.vertical) > button + button {
 spinbutton:not(.vertical) > button:hover:not(:active),
 spinbutton:not(.vertical) > button:hover + button {
   box-shadow: inset 1px 0 #2b2e39; }
+
+spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover),
+spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled {
+  box-shadow: inset 1px 0 rgba(43, 46, 57, 0.5); }
 
 spinbutton:not(.vertical) > button:first-child:hover:not(:active),
 spinbutton:not(.vertical) > button.up:dir(rtl):hover:not(:active),
@@ -887,7 +881,7 @@ toolbar, .inline-toolbar {
   toolbar:not(.inline-toolbar) .linked > entry, .inline-toolbar:not(.inline-toolbar) .linked > entry {
     margin-right: 0; }
 
-.primary-toolbar {
+.primary-toolbar:not(.libreoffice-toolbar) {
   color: rgba(207, 218, 231, 0.8);
   background-color: #2f343f;
   box-shadow: none;
@@ -1033,22 +1027,21 @@ window.csd > .titlebar:not(headerbar):backdrop {
   box-shadow: none; }
 
 .titlebar:not(headerbar) > separator {
-  background-image: linear-gradient(to top, #262a33); }
+  background-image: linear-gradient(to bottom, #262a33, #262a33); }
 
-.primary-toolbar separator, headerbar separator.titlebutton, .titlebar:not(headerbar) separator.titlebutton {
+.primary-toolbar:not(.libreoffice-toolbar) separator, headerbar separator.titlebutton, .titlebar:not(headerbar) separator.titlebutton {
   min-width: 1px;
   min-height: 1px;
   background: none;
   border-width: 0 1px;
   border-image: linear-gradient(to bottom, rgba(207, 218, 231, 0) 25%, rgba(207, 218, 231, 0.15) 25%, rgba(207, 218, 231, 0.15) 75%, rgba(207, 218, 231, 0) 75%) 0 1/0 1px stretch; }
-  .primary-toolbar separator:backdrop, headerbar separator.titlebutton:backdrop, .titlebar:not(headerbar) separator.titlebutton:backdrop {
+  .primary-toolbar:not(.libreoffice-toolbar) separator:backdrop, headerbar separator.titlebutton:backdrop, .titlebar:not(headerbar) separator.titlebutton:backdrop {
     opacity: 0.6; }
 
 .primary-toolbar entry, headerbar entry {
   color: rgba(207, 218, 231, 0.8);
   border-color: rgba(21, 23, 28, 0.4);
-  background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.4));
-  background-color: transparent; }
+  background-color: rgba(95, 105, 127, 0.4); }
   .primary-toolbar entry image, headerbar entry image, .primary-toolbar entry image:hover, headerbar entry image:hover {
     color: inherit; }
   .primary-toolbar entry:backdrop, headerbar entry:backdrop {
@@ -1056,13 +1049,14 @@ window.csd > .titlebar:not(headerbar):backdrop {
   .primary-toolbar entry:focus, headerbar entry:focus {
     color: #ffffff;
     border-color: transparent;
-    background-image: linear-gradient(to bottom, #cc575d);
+    background-color: #cc575d;
     background-clip: padding-box; }
     .primary-toolbar entry:focus image, headerbar entry:focus image {
       color: #ffffff; }
   .primary-toolbar entry:disabled, headerbar entry:disabled {
     color: rgba(207, 218, 231, 0.35);
-    background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.25)); }
+    border-color: rgba(21, 23, 28, 0.4);
+    background-color: rgba(95, 105, 127, 0.25); }
   .primary-toolbar entry selection:focus, headerbar entry selection:focus {
     background-color: #ffffff;
     color: #cc575d; }
@@ -1071,29 +1065,28 @@ window.csd > .titlebar:not(headerbar):backdrop {
     background-image: none;
     background-color: transparent; }
   .primary-toolbar entry.warning, headerbar entry.warning {
-    color: #ffffff;
+    color: white;
     border-color: rgba(21, 23, 28, 0.4);
-    background-image: linear-gradient(to bottom, #a45d39); }
+    background-color: #a45d39; }
     .primary-toolbar entry.warning:focus, headerbar entry.warning:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #F27835); }
+      color: white;
+      background-color: #F27835; }
     .primary-toolbar entry.warning selection, headerbar entry.warning selection, .primary-toolbar entry.warning selection:focus, headerbar entry.warning selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #F27835; }
   .primary-toolbar entry.error, headerbar entry.error {
-    color: #ffffff;
+    color: white;
     border-color: rgba(21, 23, 28, 0.4);
-    background-image: linear-gradient(to bottom, #aa3c3b); }
+    background-color: #aa3c3b; }
     .primary-toolbar entry.error:focus, headerbar entry.error:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138); }
+      color: white;
+      background-color: #FC4138; }
     .primary-toolbar entry.error selection, headerbar entry.error selection, .primary-toolbar entry.error selection:focus, headerbar entry.error selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
 
 .primary-toolbar button, headerbar button {
   color: rgba(207, 218, 231, 0.8);
-  outline-color: rgba(207, 218, 231, 0.1);
   outline-offset: -3px;
   background-color: rgba(47, 52, 63, 0);
   border-color: rgba(47, 52, 63, 0); }
@@ -1101,12 +1094,10 @@ window.csd > .titlebar:not(headerbar):backdrop {
     opacity: 0.7; }
   .primary-toolbar button:hover, headerbar button:hover {
     color: rgba(207, 218, 231, 0.8);
-    outline-color: rgba(207, 218, 231, 0.1);
     border-color: rgba(21, 23, 28, 0.4);
     background-color: rgba(95, 105, 127, 0.4); }
   .primary-toolbar button:active, headerbar button:active, .primary-toolbar button:checked, headerbar button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d;
     background-clip: padding-box; }
@@ -1134,19 +1125,17 @@ window.csd > .titlebar:not(headerbar):backdrop {
   border-radius: 3px;
   border-style: solid; }
 
-.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
   box-shadow: none; }
 
 .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .linked:not(.vertical).path-bar > button, headerbar .linked:not(.vertical).path-bar > button {
   color: rgba(207, 218, 231, 0.8);
-  outline-color: rgba(207, 218, 231, 0.1);
   border-color: rgba(21, 23, 28, 0.4);
   background-color: rgba(95, 105, 127, 0.4); }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar .linked:not(.vertical).path-bar > button:hover, headerbar .linked:not(.vertical).path-bar > button:hover {
     background-color: rgba(134, 144, 165, 0.4); }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar .linked:not(.vertical).path-bar > button:active, headerbar .linked:not(.vertical).path-bar > button:active, .primary-toolbar .linked:not(.vertical).path-bar > button:checked, headerbar .linked:not(.vertical).path-bar > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d; }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, .primary-toolbar .linked:not(.vertical).path-bar > button:disabled, headerbar .linked:not(.vertical).path-bar > button:disabled {
@@ -1205,26 +1194,22 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar button.suggested-action, headerbar button.suggested-action {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
-  background-color: #be3941;
-  border-color: #be3941; }
+  color: white;
+  background-color: #BE3941;
+  border-color: #BE3941; }
   .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat, .primary-toolbar button.suggested-action.sidebar-button, headerbar button.suggested-action.sidebar-button {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
-    color: #be3941;
-    outline-color: rgba(190, 57, 65, 0.3); }
+    color: #BE3941; }
   .primary-toolbar button.suggested-action:hover, headerbar button.suggested-action:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #ce5c63;
     border-color: #ce5c63; }
   .primary-toolbar button.suggested-action:active, headerbar button.suggested-action:active, .primary-toolbar button.suggested-action:checked, headerbar button.suggested-action:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #972d34;
     border-color: #972d34; }
   .primary-toolbar button.suggested-action.flat:disabled, headerbar button.suggested-action.flat:disabled, .primary-toolbar button.suggested-action.sidebar-button:disabled, headerbar button.suggested-action.sidebar-button:disabled, .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
@@ -1238,26 +1223,22 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar button.destructive-action, headerbar button.destructive-action {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
+  color: white;
   background-color: #F04A50;
   border-color: #F04A50; }
   .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat, .primary-toolbar button.destructive-action.sidebar-button, headerbar button.destructive-action.sidebar-button {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
-    color: #F04A50;
-    outline-color: rgba(240, 74, 80, 0.3); }
+    color: #F04A50; }
   .primary-toolbar button.destructive-action:hover, headerbar button.destructive-action:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #f4797e;
     border-color: #f4797e; }
   .primary-toolbar button.destructive-action:active, headerbar button.destructive-action:active, .primary-toolbar button.destructive-action:checked, headerbar button.destructive-action:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #ec1b22;
     border-color: #ec1b22; }
   .primary-toolbar button.destructive-action.flat:disabled, headerbar button.destructive-action.flat:disabled, .primary-toolbar button.destructive-action.sidebar-button:disabled, headerbar button.destructive-action.sidebar-button:disabled, .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
@@ -1275,7 +1256,6 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar spinbutton:not(.vertical) button, headerbar spinbutton:not(.vertical) button, .primary-toolbar spinbutton:not(.vertical) button:disabled, headerbar spinbutton:not(.vertical) button:disabled {
   color: rgba(207, 218, 231, 0.8);
-  outline-color: rgba(207, 218, 231, 0.1);
   border-color: rgba(21, 23, 28, 0.4);
   background-color: rgba(95, 105, 127, 0.4); }
 
@@ -1284,7 +1264,6 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar spinbutton:not(.vertical) button:active, headerbar spinbutton:not(.vertical) button:active, .primary-toolbar spinbutton:not(.vertical) button:checked, headerbar spinbutton:not(.vertical) button:checked {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   border-color: transparent;
   background-color: #cc575d; }
 
@@ -1295,6 +1274,9 @@ window.csd > .titlebar:not(headerbar):backdrop {
   border-left-style: none; }
 
 .primary-toolbar spinbutton:not(.vertical) > button:hover:not(:active), headerbar spinbutton:not(.vertical) > button:hover:not(:active), .primary-toolbar spinbutton:not(.vertical) > button:hover + button, headerbar spinbutton:not(.vertical) > button:hover + button {
+  box-shadow: inset 1px 0 rgba(21, 23, 28, 0.4); }
+
+.primary-toolbar spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover), headerbar spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover), .primary-toolbar spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled, headerbar spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled {
   box-shadow: inset 1px 0 rgba(21, 23, 28, 0.4); }
 
 .primary-toolbar spinbutton:not(.vertical) > button:first-child:hover:not(:active), headerbar spinbutton:not(.vertical) > button:first-child:hover:not(:active), .primary-toolbar spinbutton:not(.vertical) > entry + button:not(:active):hover, headerbar spinbutton:not(.vertical) > entry + button:not(:active):hover {
@@ -1309,18 +1291,18 @@ window.csd > .titlebar:not(headerbar):backdrop {
 .primary-toolbar combobox > .linked > button.combo, headerbar combobox > .linked > button.combo {
   color: rgba(207, 218, 231, 0.8);
   border-color: rgba(21, 23, 28, 0.4);
-  background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.4));
-  background-color: transparent; }
+  background-color: rgba(95, 105, 127, 0.4); }
   .primary-toolbar combobox > .linked > button.combo image, headerbar combobox > .linked > button.combo image, .primary-toolbar combobox > .linked > button.combo image:hover, headerbar combobox > .linked > button.combo image:hover {
     color: inherit; }
   .primary-toolbar combobox > .linked > button.combo:hover, headerbar combobox > .linked > button.combo:hover {
     color: #ffffff;
     border-color: transparent;
-    background-image: linear-gradient(to bottom, #cc575d);
+    background-color: #cc575d;
     box-shadow: none; }
   .primary-toolbar combobox > .linked > button.combo:disabled, headerbar combobox > .linked > button.combo:disabled {
     color: rgba(207, 218, 231, 0.35);
-    background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.25)); }
+    border-color: rgba(21, 23, 28, 0.4);
+    background-color: rgba(95, 105, 127, 0.25); }
 
 .primary-toolbar combobox > .linked > entry.combo:dir(ltr), headerbar combobox > .linked > entry.combo:dir(ltr) {
   border-right-style: none; }
@@ -1393,13 +1375,15 @@ window.csd > .titlebar:not(headerbar):backdrop {
   padding-right: 4px; }
 
 treeview.view {
-  -GtkTreeView-grid-line-width: 1;
-  -GtkTreeView-grid-line-pattern: '';
-  -GtkTreeView-tree-line-width: 1;
-  -GtkTreeView-tree-line-pattern: '';
-  -GtkTreeView-expander-size: 16;
   border-left-color: rgba(211, 218, 227, 0.15);
   border-top-color: rgba(0, 0, 0, 0.1); }
+  * {
+    -GtkTreeView-horizontal-separator: 4;
+    -GtkTreeView-grid-line-width: 1;
+    -GtkTreeView-grid-line-pattern: '';
+    -GtkTreeView-tree-line-width: 1;
+    -GtkTreeView-tree-line-pattern: '';
+    -GtkTreeView-expander-size: 16; }
   treeview.view acceleditor > label {
     background-color: #cc575d; }
   treeview.view:selected, treeview.view:selected:focus {
@@ -1437,16 +1421,21 @@ treeview.view {
   treeview.view.progressbar, treeview.view.progressbar:focus {
     color: #ffffff;
     border-radius: 3px;
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
     treeview.view.progressbar:selected, treeview.view.progressbar:selected:focus, treeview.view.progressbar:focus:selected, treeview.view.progressbar:focus:selected:focus {
       color: #cc575d;
       box-shadow: none;
-      background-image: linear-gradient(to bottom, #ffffff); }
-  treeview.view.trough, treeview.view.trough:selected, treeview.view.trough:selected:focus {
+      background-color: #ffffff; }
+  treeview.view.trough {
     color: #D3DAE3;
-    background-image: linear-gradient(to bottom, #2b2e39);
+    background-color: #2b2e39;
     border-radius: 3px;
     border-width: 0; }
+    treeview.view.trough:selected, treeview.view.trough:selected:focus {
+      color: #ffffff;
+      background-color: rgba(0, 0, 0, 0.2);
+      border-radius: 3px;
+      border-width: 0; }
   treeview.view header button {
     min-height: 0;
     min-width: 0;
@@ -1836,7 +1825,7 @@ scrollbar {
     min-height: 40px; }
 
 switch {
-  font: 1;
+  font-size: 1px;
   min-width: 52px;
   min-height: 24px;
   background-size: 52px 24px;
@@ -2337,9 +2326,11 @@ frame > border,
   padding: 0;
   border-radius: 0;
   border: 1px solid #2b2e39; }
-  frame > border.flat,
-  .frame.flat {
-    border-style: none; }
+
+frame.flat > border,
+frame > border.flat,
+.frame.flat {
+  border-style: none; }
 
 scrolledwindow viewport.frame {
   border-style: none; }
@@ -2471,19 +2462,16 @@ row.activatable:selected.has-open-popup, row.activatable:selected:hover {
     border: none; }
   .app-notification button {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: rgba(102, 109, 132, 0.4); }
     .app-notification button.flat, .app-notification button.sidebar-button {
       border-color: rgba(204, 87, 93, 0); }
     .app-notification button:hover {
       color: #BAC3CF;
-      outline-color: rgba(186, 195, 207, 0.3);
       border-color: rgba(26, 28, 34, 0.4);
       background-color: rgba(119, 127, 151, 0.5); }
     .app-notification button:active, .app-notification button:checked {
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.4);
       background-color: #cc575d;
       background-clip: padding-box; }
@@ -2509,24 +2497,16 @@ calendar {
   border-radius: 3px;
   padding: 2px; }
   calendar:selected {
-    background-color: #cc575d;
-    color: #ffffff;
     border-radius: 1.5px; }
   calendar.header {
     color: #D3DAE3;
-    border: none;
-    border-radius: 0; }
-  calendar.button, calendar.button:focus {
-    color: rgba(211, 218, 227, 0.45);
-    border-color: transparent;
-    background-color: transparent;
-    background-image: none; }
-    calendar.button:hover, calendar.button:focus:hover {
+    border: none; }
+  calendar.button {
+    color: rgba(211, 218, 227, 0.45); }
+    calendar.button:hover {
       color: #D3DAE3; }
-    calendar.button:disabled, calendar.button:focus:disabled {
-      color: rgba(211, 218, 227, 0.45);
-      background-color: transparent;
-      background-image: none; }
+    calendar.button:disabled {
+      color: rgba(211, 218, 227, 0.45); }
   calendar:indeterminate {
     color: alpha(currentColor,0.55); }
   calendar.highlight {
@@ -2627,7 +2607,7 @@ placessidebar row {
   placessidebar row.sidebar-placeholder-row {
     padding: 0 8px;
     min-height: 2px;
-    background-image: linear-gradient(to top, #F08437);
+    background-image: linear-gradient(to bottom, #F08437, #F08437);
     background-clip: content-box; }
   placessidebar row.sidebar-new-bookmark-row {
     color: #cc575d; }
@@ -2657,15 +2637,15 @@ paned > separator {
   -gtk-icon-source: none;
   border-style: none;
   background-color: transparent;
-  background-image: linear-gradient(to top, #2b2e39);
+  background-image: linear-gradient(to bottom, #2b2e39, #2b2e39);
   background-size: 1px 1px; }
   paned > separator:selected {
-    background-image: linear-gradient(to top, #cc575d); }
+    background-image: linear-gradient(to bottom, #cc575d, #cc575d); }
   paned > separator.wide {
     min-width: 5px;
     min-height: 5px;
     background-color: #383C4A;
-    background-image: linear-gradient(to top, #2b2e39), linear-gradient(to top, #2b2e39);
+    background-image: linear-gradient(to bottom, #2b2e39, #2b2e39), linear-gradient(to bottom, #2b2e39, #2b2e39);
     background-size: 1px 1px, 1px 1px; }
 
 paned.horizontal > separator {
@@ -2697,107 +2677,44 @@ paned.vertical > separator {
 
 infobar {
   border-style: none; }
+  infobar.info, infobar.question, infobar.warning, infobar.error {
+    background-color: #cc575d;
+    color: #ffffff;
+    caret-color: currentColor; }
+    infobar.info selection, infobar.question selection, infobar.warning selection, infobar.error selection {
+      color: #cc575d;
+      background-color: #ffffff; }
 
-.info,
-.question,
-.warning,
-.error {
-  background-color: #cc575d;
-  color: #ffffff; }
-  .info label:selected:focus, .info label:selected:hover, .info label:selected,
-  .question label:selected:focus,
-  .question label:selected:hover,
-  .question label:selected,
-  .warning label:selected:focus,
-  .warning label:selected:hover,
-  .warning label:selected,
-  .error label:selected:focus,
-  .error label:selected:hover,
-  .error label:selected {
-    color: #cc575d;
-    background-color: #ffffff; }
-
-.selection-mode.primary-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, .info button,
-.question button,
-.warning button,
-.error button, .nautilus-window .floating-bar button {
+.selection-mode.primary-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, infobar.info button, infobar.question button, infobar.warning button, infobar.error button, .nautilus-window .floating-bar button {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.5); }
 
-row:selected button.flat, row:selected button.sidebar-button, .info button.flat, .info button.sidebar-button,
-.question button.flat,
-.question button.sidebar-button,
-.warning button.flat,
-.warning button.sidebar-button,
-.error button.flat,
-.error button.sidebar-button, .nautilus-window .floating-bar button.flat, .nautilus-window .floating-bar button.sidebar-button {
+row:selected button.flat, row:selected button.sidebar-button, infobar.info button.flat, infobar.info button.sidebar-button, infobar.question button.flat, infobar.question button.sidebar-button, infobar.warning button.flat, infobar.warning button.sidebar-button, infobar.error button.flat, infobar.error button.sidebar-button, .nautilus-window .floating-bar button.flat, .nautilus-window .floating-bar button.sidebar-button {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0); }
-  .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, row:selected button.flat:disabled, row:selected button.sidebar-button:disabled, .info button.flat:disabled, .info button.sidebar-button:disabled,
-  .question button.flat:disabled,
-  .question button.sidebar-button:disabled,
-  .warning button.flat:disabled,
-  .warning button.sidebar-button:disabled,
-  .error button.flat:disabled,
-  .error button.sidebar-button:disabled, .nautilus-window .floating-bar button.flat:disabled, .nautilus-window .floating-bar button.sidebar-button:disabled, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled label, row:selected button.sidebar-button:disabled label, .info button.flat:disabled label, .info button.sidebar-button:disabled label,
-  .question button.flat:disabled label,
-  .question button.sidebar-button:disabled label,
-  .warning button.flat:disabled label,
-  .warning button.sidebar-button:disabled label,
-  .error button.flat:disabled label,
-  .error button.sidebar-button:disabled label, .nautilus-window .floating-bar button.flat:disabled label, .nautilus-window .floating-bar button.sidebar-button:disabled label {
+  .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, row:selected button.flat:disabled, row:selected button.sidebar-button:disabled, infobar.info button.flat:disabled, infobar.info button.sidebar-button:disabled, infobar.question button.flat:disabled, infobar.question button.sidebar-button:disabled, infobar.warning button.flat:disabled, infobar.warning button.sidebar-button:disabled, infobar.error button.flat:disabled, infobar.error button.sidebar-button:disabled, .nautilus-window .floating-bar button.flat:disabled, .nautilus-window .floating-bar button.sidebar-button:disabled, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled label, row:selected button.sidebar-button:disabled label, infobar.info button.flat:disabled label, infobar.info button.sidebar-button:disabled label, infobar.question button.flat:disabled label, infobar.question button.sidebar-button:disabled label, infobar.warning button.flat:disabled label, infobar.warning button.sidebar-button:disabled label, infobar.error button.flat:disabled label, infobar.error button.sidebar-button:disabled label, .nautilus-window .floating-bar button.flat:disabled label, .nautilus-window .floating-bar button.sidebar-button:disabled label {
     color: rgba(255, 255, 255, 0.4); }
 
-row:selected button:hover, .info button:hover,
-.question button:hover,
-.warning button:hover,
-.error button:hover, .nautilus-window .floating-bar button:hover {
+row:selected button:hover, infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover, .nautilus-window .floating-bar button:hover {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   background-color: rgba(255, 255, 255, 0.2);
   border-color: rgba(255, 255, 255, 0.8); }
 
-.selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, .info button:active,
-.question button:active,
-.warning button:active,
-.error button:active, .nautilus-window .floating-bar button:active, .selection-mode.primary-toolbar button:hover:active, headerbar.selection-mode button:hover:active, .selection-mode.primary-toolbar button:hover:checked, headerbar.selection-mode button:hover:checked, row:selected button:active:hover, .info button:active:hover,
-.question button:active:hover,
-.warning button:active:hover,
-.error button:active:hover, .nautilus-window .floating-bar button:active:hover, row:selected button:checked, .info button:checked,
-.question button:checked,
-.warning button:checked,
-.error button:checked, .nautilus-window .floating-bar button:checked {
+.selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, .nautilus-window .floating-bar button:active, .selection-mode.primary-toolbar button:hover:active, headerbar.selection-mode button:hover:active, .selection-mode.primary-toolbar button:hover:checked, headerbar.selection-mode button:hover:checked, row:selected button:active:hover, infobar.info button:active:hover, infobar.question button:active:hover, infobar.warning button:active:hover, infobar.error button:active:hover, .nautilus-window .floating-bar button:active:hover, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked, .nautilus-window .floating-bar button:checked {
   color: #cc575d;
-  outline-color: rgba(204, 87, 93, 0.3);
   background-color: #ffffff;
   border-color: #ffffff; }
 
-row:selected button:disabled, .info button:disabled,
-.question button:disabled,
-.warning button:disabled,
-.error button:disabled, .nautilus-window .floating-bar button:disabled {
+row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, .nautilus-window .floating-bar button:disabled {
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.4); }
-  row:selected button:disabled, .info button:disabled,
-  .question button:disabled,
-  .warning button:disabled,
-  .error button:disabled, .nautilus-window .floating-bar button:disabled, row:selected button:disabled label, .info button:disabled label,
-  .question button:disabled label,
-  .warning button:disabled label,
-  .error button:disabled label, .nautilus-window .floating-bar button:disabled label {
+  row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, .nautilus-window .floating-bar button:disabled, row:selected button:disabled label, infobar.info button:disabled label, infobar.question button:disabled label, infobar.warning button:disabled label, infobar.error button:disabled label, .nautilus-window .floating-bar button:disabled label {
     color: rgba(255, 255, 255, 0.5); }
-  .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, row:selected button:disabled:active, .info button:disabled:active,
-  .question button:disabled:active,
-  .warning button:disabled:active,
-  .error button:disabled:active, .nautilus-window .floating-bar button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:checked, .info button:disabled:checked,
-  .question button:disabled:checked,
-  .warning button:disabled:checked,
-  .error button:disabled:checked, .nautilus-window .floating-bar button:disabled:checked {
+  .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, .nautilus-window .floating-bar button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked, .nautilus-window .floating-bar button:disabled:checked {
     color: #cc575d;
     background-color: rgba(255, 255, 255, 0.5);
     border-color: rgba(255, 255, 255, 0.4); }
@@ -2872,12 +2789,10 @@ colorswatch#add-color-button {
   border-style: solid;
   border-width: 1px;
   color: #D3DAE3;
-  outline-color: rgba(211, 218, 227, 0.3);
   border-color: #2b2e39;
   background-color: #444a58; }
   colorswatch#add-color-button:hover {
     color: #D3DAE3;
-    outline-color: rgba(211, 218, 227, 0.3);
     border-color: #2b2e39;
     background-color: #505666; }
   colorswatch#add-color-button overlay {
@@ -2901,7 +2816,6 @@ colorchooser .popover.osd {
 
 .scale-popup button:hover {
   color: #D3DAE3;
-  outline-color: rgba(211, 218, 227, 0.3);
   border-color: #2b2e39;
   background-color: #505666; }
 
@@ -2910,13 +2824,14 @@ popover.background.touch-selection, .csd popover.background.touch-selection {
   font: initial; }
 
 .monospace {
-  font: Monospace; }
+  font-family: Monospace; }
 
 button.circular, button.nautilus-circular-button.image-button,
 button.circular-button {
   padding: 0;
-  min-width: 26px;
-  min-height: 26px;
+  min-width: 16px;
+  min-height: 24px;
+  padding: 2px 6px;
   border-radius: 50%;
   -gtk-outline-radius: 50%; }
   button.circular label, button.nautilus-circular-button.image-button label,
@@ -2994,14 +2909,12 @@ headerbar button.titlebutton,
   headerbar button.titlebutton:hover,
   .titlebar button.titlebutton:hover {
     color: rgba(207, 218, 231, 0.8);
-    outline-color: rgba(207, 218, 231, 0.1);
     border-color: rgba(21, 23, 28, 0.4);
     background-color: rgba(95, 105, 127, 0.4); }
   headerbar button.titlebutton:active, headerbar button.titlebutton:checked,
   .titlebar button.titlebutton:active,
   .titlebar button.titlebutton:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d; }
   headerbar button.titlebutton.close, headerbar button.titlebutton.maximize, headerbar button.titlebutton.minimize,
@@ -3063,7 +2976,7 @@ textview text selection, flowbox flowboxchild:selected, entry selection:focus, e
 modelbutton.flat:active,
 modelbutton.flat:active arrow,
 modelbutton.flat:selected,
-modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
+modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, calendar:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
 .nautilus-window placessidebar.sidebar row.sidebar-row.has-open-popup:selected,
 .nautilus-window placessidebar.sidebar row.sidebar-row:selected,
 .nautilus-window placessidebar.sidebar row.sidebar-row:selected:hover,
@@ -3077,20 +2990,19 @@ modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:
   modelbutton.flat:active,
   modelbutton.flat:active arrow,
   modelbutton.flat:selected,
-  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
+  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, calendar:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
   .nautilus-window placessidebar.sidebar row.sidebar-row.has-open-popup:selected,
   .nautilus-window placessidebar.sidebar row.sidebar-row:selected,
   .nautilus-window placessidebar.sidebar row.sidebar-row:selected:hover,
   .nautilus-window placessidebar.sidebar row.sidebar-row:active:hover {
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3); }
+    color: #ffffff; }
     row:selected label:disabled, label:disabled:selected, .view:disabled:selected, iconview:disabled:selected, iconview:disabled:selected:focus, .view text:disabled:selected, iconview text:disabled:selected,
     textview text:disabled:selected, iconview text selection:disabled:focus, .view text selection:disabled, iconview text selection:disabled,
     textview text selection:disabled, flowbox flowboxchild:disabled:selected, label:disabled selection, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
     modelbutton.flat:disabled:active,
     modelbutton.flat:active arrow:disabled,
     modelbutton.flat:disabled:selected,
-    modelbutton.flat:selected arrow:disabled, treeview.view:disabled:selected:focus, row:disabled:selected, .nemo-window .nemo-window-pane widget.entry:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:active:hover,
+    modelbutton.flat:selected arrow:disabled, treeview.view:disabled:selected:focus, row:disabled:selected, calendar:disabled:selected, .nemo-window .nemo-window-pane widget.entry:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:active:hover,
     .nautilus-window placessidebar.sidebar row.sidebar-row:disabled:selected,
     .nautilus-window placessidebar.sidebar row.sidebar-row:disabled:active:hover {
       color: #e6abae; }
@@ -3099,10 +3011,12 @@ modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:
 terminal-window notebook > header.top > tabs > tab:checked {
   box-shadow: inset 0 -1px #2b2e39; }
 
-terminal-window notebook > header.top {
+terminal-window notebook > header.top,
+.mate-terminal notebook > header.top {
   padding-top: 3px;
   box-shadow: inset 0 1px #262a33, inset 0 -1px #2b2e39; }
-  terminal-window notebook > header.top button {
+  terminal-window notebook > header.top button,
+  .mate-terminal notebook > header.top button {
     padding: 0;
     min-width: 24px;
     min-height: 24px; }
@@ -3111,7 +3025,7 @@ terminal-window notebook > header.top {
   border-radius: 2px; }
 
 .nautilus-desktop.nautilus-canvas-item, .nemo-desktop.nemo-canvas-item, .caja-desktop {
-  color: #ffffff;
+  color: white;
   text-shadow: 1px 1px rgba(0, 0, 0, 0.6); }
   .nautilus-desktop.nautilus-canvas-item:active, .nemo-desktop.nemo-canvas-item:active, .caja-desktop:active {
     color: #D3DAE3; }
@@ -3154,12 +3068,10 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
 @keyframes needs_attention_keyframes {
   0% {
     color: rgba(207, 218, 231, 0.8);
-    outline-color: rgba(207, 218, 231, 0.1);
     border-color: rgba(21, 23, 28, 0.4);
     background-color: rgba(95, 105, 127, 0.4); }
   100% {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d; } }
 
@@ -3169,6 +3081,17 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
 .nautilus-operations-button-needs-attention-multiple {
   animation: needs_attention_keyframes 3s ease-in-out;
   animation-iteration-count: 3; }
+
+.conflict-row.activatable, .conflict-row.activatable:active {
+  color: white;
+  background-color: #FC4138; }
+
+.conflict-row.activatable:hover {
+  background-color: #fd716a; }
+
+.conflict-row.activatable:selected {
+  color: #ffffff;
+  background-color: #cc575d; }
 
 .nemo-window .nemo-places-sidebar.frame {
   border-width: 0; }
@@ -3182,12 +3105,10 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
   color: #D3DAE3;
   border-color: #2b2e39;
   background-color: #404552;
-  background-image: linear-gradient(to bottom, #404552);
   box-shadow: inset 1px 0 #cc575d, inset -1px 0 #cc575d, inset 0 1px #cc575d, inset 0 -1px #cc575d; }
 
 .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button {
   color: rgba(207, 218, 231, 0.8);
-  outline-color: rgba(207, 218, 231, 0.1);
   border-color: rgba(21, 23, 28, 0.4);
   background-color: rgba(95, 105, 127, 0.4); }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:not(:last-child):not(:only-child) {
@@ -3196,7 +3117,6 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
     background-color: rgba(134, 144, 165, 0.4); }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:active, .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d; }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:disabled {
@@ -3290,6 +3210,26 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
   margin: 2px;
   padding: 2px; }
 
+.gedit-map-frame border {
+  border-width: 0; }
+  .gedit-map-frame border:dir(ltr) {
+    border-left-width: 1px; }
+  .gedit-map-frame border:dir(rtl) {
+    border-right-width: 1px; }
+
+.pluma-window statusbar frame > border {
+  border: none; }
+
+.pluma-window notebook > stack scrolledwindow {
+  border-width: 0 0 1px 0; }
+
+#pluma-status-combo-button {
+  min-height: 0;
+  padding: 0;
+  border-top: none;
+  border-bottom: none;
+  border-radius: 0; }
+
 .gb-search-entry-occurrences-tag {
   background: none; }
 
@@ -3318,6 +3258,8 @@ pillbox {
   color: #ffffff;
   background-color: #cc575d;
   border-radius: 3px; }
+  pillbox:disabled label {
+    color: rgba(255, 255, 255, 0.5); }
 
 docktabstrip {
   padding: 0 6px;
@@ -3350,6 +3292,62 @@ dockoverlayedge {
   dockoverlayedge.left-edge tab:checked,
   dockoverlayedge.right-edge tab:checked {
     border-width: 1px 0; }
+
+popover.messagepopover.background {
+  padding: 0; }
+
+popover.messagepopover .popover-content-area {
+  margin: 16px; }
+
+popover.messagepopover .popover-action-area {
+  margin: 8px; }
+  popover.messagepopover .popover-action-area button:not(:first-child):not(:last-child) {
+    margin: 0 4px; }
+
+popover.popover-selector {
+  padding: 0; }
+  popover.popover-selector list row {
+    padding: 5px 0; }
+  popover.popover-selector list row image {
+    margin-left: 3px;
+    margin-right: 10px; }
+
+entry.search.preferences-search {
+  border: none;
+  border-right: 1px solid #2b2e39;
+  border-bottom: 1px solid #2b2e39;
+  border-radius: 0; }
+
+preferences stacksidebar.sidebar list {
+  background-image: linear-gradient(to bottom, #404552, #404552); }
+
+preferences stacksidebar.sidebar list separator {
+  background-color: transparent; }
+
+devhelppanel entry:focus,
+symboltreepanel entry:focus {
+  border-color: #2b2e39; }
+
+button.run-arrow-button {
+  min-width: 12px; }
+
+omnibar.linked > entry:not(:only-child) {
+  border-style: solid;
+  border-radius: 3px;
+  margin-left: 1px;
+  margin-right: 1px; }
+
+gstyleslidein #scale_box button.toggle:checked,
+gstyleslidein #strings_controls button.toggle:checked,
+gstyleslidein #palette_controls button.toggle:checked,
+gstyleslidein #components_controls button.toggle:checked {
+  color: #D3DAE3; }
+
+configurationview entry.flat {
+  background: none; }
+
+configurationview list {
+  border-width: 0; }
 
 .documents-scrolledwin.frame {
   border-width: 0; }
@@ -3398,46 +3396,119 @@ button.documents-favorite:active:hover {
   opacity: 0.0;
   transition: opacity 0.2s ease-out; }
 
+.tweak-categories,
+.tweak-category:not(:selected):not(:hover) {
+  background-image: linear-gradient(to bottom, #404552, #404552); }
+
 .tr-workarea undershoot,
 .tr-workarea overshoot {
   border-color: transparent; }
 
-.gnome-panel-menu-bar, .gnome-panel-menu-bar menubar,
-.mate-panel-menu-bar,
-.mate-panel-menu-bar menubar {
+.atril-window .primary-toolbar toolbar, .atril-window .primary-toolbar .inline-toolbar {
+  background: none; }
+
+#gf-bubble, #gf-bubble.solid,
+#gf-osd-window,
+#gf-osd-window.solid,
+#gf-input-source-popup,
+#gf-input-source-popup.solid,
+#gf-candidate-popup,
+#gf-candidate-popup.solid {
+  color: #cfd5de;
+  background-color: #353945;
+  border: 1px solid #23262e;
+  border-radius: 2px; }
+
+#gf-bubble levelbar block.low, #gf-bubble levelbar block.high, #gf-bubble levelbar block.full,
+#gf-osd-window levelbar block.low,
+#gf-osd-window levelbar block.high,
+#gf-osd-window levelbar block.full,
+#gf-input-source-popup levelbar block.low,
+#gf-input-source-popup levelbar block.high,
+#gf-input-source-popup levelbar block.full,
+#gf-candidate-popup levelbar block.low,
+#gf-candidate-popup levelbar block.high,
+#gf-candidate-popup levelbar block.full {
+  background-color: #cc575d;
+  border-color: #cc575d; }
+
+#gf-bubble levelbar block.empty,
+#gf-osd-window levelbar block.empty,
+#gf-input-source-popup levelbar block.empty,
+#gf-candidate-popup levelbar block.empty {
+  background-color: #2a2d37; }
+
+#gf-bubble levelbar trough,
+#gf-osd-window levelbar trough,
+#gf-input-source-popup levelbar trough,
+#gf-candidate-popup levelbar trough {
+  background: none; }
+
+#gf-input-source {
+  min-height: 32px;
+  min-width: 40px; }
+  #gf-input-source:selected {
+    color: #ffffff;
+    background-color: #cc575d;
+    border-radius: 2px; }
+
+gf-candidate-box label {
+  padding: 3px; }
+
+gf-candidate-box:hover, gf-candidate-box:selected {
+  color: #ffffff;
+  background-color: #cc575d;
+  border-radius: 2px; }
+
+MsdOsdWindow.background.osd {
+  border-radius: 2px;
+  border: 1px solid #23262e; }
+  MsdOsdWindow.background.osd .progressbar {
+    background-color: #cc575d;
+    border: none;
+    border-color: red;
+    border-radius: 5px; }
+  MsdOsdWindow.background.osd .trough {
+    background-color: #2a2d37;
+    border: none;
+    border-radius: 5px; }
+
+.mate-panel-menu-bar, .mate-panel-menu-bar menubar,
+panel-toplevel.background,
+panel-toplevel.background menubar {
   background-color: #2b2e37; }
 
-.gnome-panel-menu-bar menubar,
-.gnome-panel-menu-bar #PanelApplet label,
-.gnome-panel-menu-bar #PanelApplet image,
 .mate-panel-menu-bar menubar,
 .mate-panel-menu-bar #PanelApplet label,
-.mate-panel-menu-bar #PanelApplet image {
+.mate-panel-menu-bar #PanelApplet image,
+panel-toplevel.background menubar,
+panel-toplevel.background #PanelApplet label,
+panel-toplevel.background #PanelApplet image {
   color: #BAC3CF; }
 
-.gnome-panel-menu-bar button label, .gnome-panel-menu-bar button image,
-.gnome-panel-menu-bar #tasklist-button label,
-.gnome-panel-menu-bar #tasklist-button image,
-.mate-panel-menu-bar button label,
-.mate-panel-menu-bar button image,
+.mate-panel-menu-bar button label, .mate-panel-menu-bar button image,
 .mate-panel-menu-bar #tasklist-button label,
-.mate-panel-menu-bar #tasklist-button image {
+.mate-panel-menu-bar #tasklist-button image,
+panel-toplevel.background button label,
+panel-toplevel.background button image,
+panel-toplevel.background #tasklist-button label,
+panel-toplevel.background #tasklist-button image {
   color: inherit; }
 
-.gnome-panel-menu-bar .wnck-pager,
-.mate-panel-menu-bar .wnck-pager {
+.mate-panel-menu-bar .wnck-pager,
+panel-toplevel.background .wnck-pager {
   color: #5d6268;
   background-color: #14161b; }
-  .gnome-panel-menu-bar .wnck-pager:hover,
-  .mate-panel-menu-bar .wnck-pager:hover {
+  .mate-panel-menu-bar .wnck-pager:hover,
+  panel-toplevel.background .wnck-pager:hover {
     background-color: #363a46; }
-  .gnome-panel-menu-bar .wnck-pager:selected,
-  .mate-panel-menu-bar .wnck-pager:selected {
+  .mate-panel-menu-bar .wnck-pager:selected,
+  panel-toplevel.background .wnck-pager:selected {
     color: #e4a5a8;
     background-color: #cc575d; }
 
-.gnome-panel-menu-bar na-tray-applet,
-.mate-panel-menu-bar na-tray-applet {
+.mate-panel-menu-bar na-tray-applet,
+panel-toplevel.background na-tray-applet {
   -NaTrayApplet-icon-padding: 0;
   -NaTrayApplet-icon-size: 16px; }
 
@@ -3455,26 +3526,32 @@ button.documents-favorite:active:hover {
     color: #d8dde4;
     background-color: rgba(0, 0, 0, 0.17); }
   #tasklist-button:checked {
-    color: #ffffff;
+    color: white;
     background-color: rgba(0, 0, 0, 0.25);
     box-shadow: inset 0 -2px #cc575d; }
 
-.gnome-panel-menu-bar button:not(#tasklist-button),
-.mate-panel-menu-bar button:not(#tasklist-button), .xfce4-panel.panel button.flat, .xfce4-panel.panel button.sidebar-button {
+.mate-panel-menu-bar button:not(#tasklist-button),
+panel-toplevel.background button:not(#tasklist-button), .xfce4-panel.panel button.flat, .xfce4-panel.panel button.sidebar-button {
   color: #BAC3CF;
   border-radius: 0;
   border: none;
   background-color: rgba(43, 46, 55, 0); }
-  .gnome-panel-menu-bar button:hover:not(#tasklist-button),
-  .mate-panel-menu-bar button:hover:not(#tasklist-button), .xfce4-panel.panel button.flat:hover, .xfce4-panel.panel button.sidebar-button:hover {
+  .mate-panel-menu-bar button:hover:not(#tasklist-button),
+  panel-toplevel.background button:hover:not(#tasklist-button), .xfce4-panel.panel button.flat:hover, .xfce4-panel.panel button.sidebar-button:hover {
     border: none;
     background-color: #414654; }
-  .gnome-panel-menu-bar button:active:not(#tasklist-button),
-  .mate-panel-menu-bar button:active:not(#tasklist-button), .xfce4-panel.panel button.flat:active, .xfce4-panel.panel button.sidebar-button:active, .gnome-panel-menu-bar button:checked:not(#tasklist-button),
-  .mate-panel-menu-bar button:checked:not(#tasklist-button), .xfce4-panel.panel button.flat:checked, .xfce4-panel.panel button.sidebar-button:checked {
+  .mate-panel-menu-bar button:active:not(#tasklist-button),
+  panel-toplevel.background button:active:not(#tasklist-button), .xfce4-panel.panel button.flat:active, .xfce4-panel.panel button.sidebar-button:active, .mate-panel-menu-bar button:checked:not(#tasklist-button),
+  panel-toplevel.background button:checked:not(#tasklist-button), .xfce4-panel.panel button.flat:checked, .xfce4-panel.panel button.sidebar-button:checked {
     color: #ffffff;
     border: none;
     background-color: #cc575d; }
+    .mate-panel-menu-bar button:active:not(#tasklist-button) label,
+    panel-toplevel.background button:active:not(#tasklist-button) label, .xfce4-panel.panel button.flat:active label, .xfce4-panel.panel button.sidebar-button:active label, .mate-panel-menu-bar button:active:not(#tasklist-button) image,
+    panel-toplevel.background button:active:not(#tasklist-button) image, .xfce4-panel.panel button.flat:active image, .xfce4-panel.panel button.sidebar-button:active image, .mate-panel-menu-bar button:checked:not(#tasklist-button) label,
+    panel-toplevel.background button:checked:not(#tasklist-button) label, .xfce4-panel.panel button.flat:checked label, .xfce4-panel.panel button.sidebar-button:checked label, .mate-panel-menu-bar button:checked:not(#tasklist-button) image,
+    panel-toplevel.background button:checked:not(#tasklist-button) image, .xfce4-panel.panel button.flat:checked image, .xfce4-panel.panel button.sidebar-button:checked image {
+      color: inherit; }
 
 .nautilus-window .floating-bar {
   padding: 1px;
@@ -3496,17 +3573,17 @@ button.documents-favorite:active:hover {
   padding-right: 4px;
   color: rgba(207, 218, 231, 0.8);
   border-color: rgba(21, 23, 28, 0.4);
-  background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.4));
-  background-color: transparent; }
+  background-color: rgba(95, 105, 127, 0.4); }
   .marlin-pathbar.pathbar image, .marlin-pathbar.pathbar image:hover {
     color: inherit; }
   .marlin-pathbar.pathbar:focus {
     color: #ffffff;
     border-color: transparent;
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
   .marlin-pathbar.pathbar:disabled {
     color: rgba(207, 218, 231, 0.35);
-    background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.25)); }
+    border-color: rgba(21, 23, 28, 0.4);
+    background-color: rgba(95, 105, 127, 0.25); }
   .marlin-pathbar.pathbar:active, .marlin-pathbar.pathbar:checked {
     color: #cc575d; }
 
@@ -3514,7 +3591,7 @@ button.documents-favorite:active:hover {
   border: 1px solid rgba(0, 0, 0, 0.35);
   border-radius: 3px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  background-image: linear-gradient(to bottom, white);
+  background-image: linear-gradient(to bottom, white, white);
   background-color: transparent; }
   .gala-notification .title, .gala-notification .label {
     color: #5c616c; }
@@ -3581,24 +3658,25 @@ UnityDecoration {
   -UnityDecoration-title-indent: 10px;
   -UnityDecoration-title-fade: 35px;
   -UnityDecoration-title-alignment: 0.0; }
-  UnityDecoration.top {
+  UnityDecoration .top {
     border: 1px solid #20232b;
     border-bottom-width: 0;
     border-radius: 4px 4px 0 0;
     padding: 1px 6px 0 6px;
-    background-image: linear-gradient(to bottom, #2f343f);
+    background-image: linear-gradient(to bottom, #2f343f, #2f343f);
     color: rgba(207, 218, 231, 0.8);
     box-shadow: inset 0 1px #363b48; }
-    UnityDecoration.top:backdrop {
+    UnityDecoration .top:backdrop {
       border-bottom-width: 0;
       color: rgba(207, 218, 231, 0.5); }
-  UnityDecoration.left, UnityDecoration.right, UnityDecoration.bottom, UnityDecoration.left:backdrop, UnityDecoration.right:backdrop, UnityDecoration.bottom:backdrop {
+  UnityDecoration .left, UnityDecoration .right, UnityDecoration .bottom,
+  UnityDecoration .left:backdrop, UnityDecoration .right:backdrop, UnityDecoration .bottom:backdrop {
     background-color: transparent;
-    background-image: linear-gradient(to bottom, #20232b); }
+    background-image: linear-gradient(to bottom, #20232b, #20232b); }
 
 UnityPanelWidget,
 .unity-panel {
-  background-image: linear-gradient(to bottom, #2f343f);
+  background-image: linear-gradient(to bottom, #2f343f, #2f343f);
   color: #f6f7f9;
   box-shadow: none; }
   UnityPanelWidget:backdrop,
@@ -3609,7 +3687,7 @@ UnityPanelWidget,
 .unity-panel.menubar .menuitem *:hover {
   border-radius: 0;
   color: #ffffff;
-  background-image: linear-gradient(to bottom, #cc575d);
+  background-image: linear-gradient(to bottom, #cc575d, #cc575d);
   border-bottom: none; }
 
 .lightdm.menu {
@@ -3802,7 +3880,7 @@ GraniteWidgetsWelcome {
 
 GraniteWidgetsWelcome label {
   color: #868b97;
-  font: open sans 11;
+  font-size: 11px;
   text-shadow: none; }
 
 GraniteWidgetsWelcome .h1,
@@ -3822,7 +3900,7 @@ GraniteWidgetsPopOver {
   margin: 0; }
 
 .popover_bg {
-  background-image: linear-gradient(to bottom, #404552);
+  background-image: linear-gradient(to bottom, #404552, #404552);
   border: 1px solid rgba(0, 0, 0, 0.3); }
 
 GraniteWidgetsPopOver .sidebar.view, GraniteWidgetsPopOver iconview.sidebar,
@@ -3833,13 +3911,13 @@ GraniteWidgetsXsEntry entry {
   padding: 4px; }
 
 .h1 {
-  font: open sans 24px; }
+  font-size: 24px; }
 
 .h2 {
-  font: open sans light 18px; }
+  font-size: 18px; }
 
 .h3 {
-  font: open sans 11px; }
+  font-size: 11px; }
 
 .h4,
 .category-label {
@@ -3856,24 +3934,25 @@ GtkListBox .h4 {
 #panel_window {
   background-color: #2b2e37;
   color: #BAC3CF;
-  font: bold;
+  font-weight: bold;
   box-shadow: inset 0 -1px #1b1d23; }
-  #panel_window menubar,
-  #panel_window menubar > menuitem {
-    background-color: transparent;
-    color: #BAC3CF;
-    font: bold; }
+  #panel_window menubar {
+    padding-left: 5px; }
+    #panel_window menubar, #panel_window menubar > menuitem {
+      background-color: transparent;
+      color: #BAC3CF;
+      font-weight: bold; }
   #panel_window menubar menuitem:disabled {
     color: rgba(186, 195, 207, 0.5); }
     #panel_window menubar menuitem:disabled label {
       color: inherit; }
   #panel_window menubar menu > menuitem {
-    font: normal; }
+    font-weight: normal; }
 
 #login_window,
 #shutdown_dialog,
 #restart_dialog {
-  font: normal;
+  font-weight: normal;
   border-style: none;
   background-color: transparent;
   color: #D3DAE3; }
@@ -3888,17 +3967,14 @@ GtkListBox .h4 {
 
 #content_frame button {
   color: #D3DAE3;
-  outline-color: rgba(211, 218, 227, 0.3);
   border-color: #2b2e39;
   background-color: #444a58; }
   #content_frame button:hover {
     color: #D3DAE3;
-    outline-color: rgba(211, 218, 227, 0.3);
     border-color: #2b2e39;
     background-color: #505666; }
   #content_frame button:active, #content_frame button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #2b2e39;
     background-color: #cc575d; }
   #content_frame button:disabled {
@@ -3920,17 +3996,14 @@ GtkListBox .h4 {
 
 #buttonbox_frame button {
   color: #BAC3CF;
-  outline-color: rgba(186, 195, 207, 0.3);
   border-color: rgba(26, 28, 34, 0.4);
   background-color: rgba(102, 109, 132, 0.4); }
   #buttonbox_frame button:hover {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: rgba(119, 127, 151, 0.5); }
   #buttonbox_frame button:active, #buttonbox_frame button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: #cc575d; }
   #buttonbox_frame button:disabled {
@@ -3940,9 +4013,9 @@ GtkListBox .h4 {
 
 #login_window #user_combobox {
   color: #D3DAE3;
-  font: 13px; }
+  font-size: 13px; }
   #login_window #user_combobox menu {
-    font: normal; }
+    font-weight: normal; }
 
 #user_image {
   padding: 3px;
@@ -3950,51 +4023,45 @@ GtkListBox .h4 {
 
 #shutdown_button.button {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
+  color: green;
   background-color: #F04A50;
   border-color: #F04A50; }
   #shutdown_button.button:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #f4797e;
     border-color: #f4797e; }
   #shutdown_button.button:active, #shutdown_button.button:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #ec1b22;
     border-color: #ec1b22; }
 
 #restart_button.button {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
-  background-color: #be3941;
-  border-color: #be3941; }
+  color: green;
+  background-color: #BE3941;
+  border-color: #BE3941; }
   #restart_button.button:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #ce5c63;
     border-color: #ce5c63; }
   #restart_button.button:active, #restart_button.button:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #972d34;
     border-color: #972d34; }
 
 #greeter_infobar {
   border-bottom-width: 0;
-  font: bold; }
+  font-weight: bold; }
 
 .nautilus-window paned > separator {
-  background-image: linear-gradient(to top, #2a2d37); }
+  background-image: linear-gradient(to bottom, #2a2d37, #2a2d37); }
 
 filechooser paned > separator {
-  background-image: linear-gradient(to top, #2a2d37); }
+  background-image: linear-gradient(to bottom, #2a2d37, #2a2d37); }
 
 filechooser.csd.background, filechooser placessidebar list,
 .nautilus-window.csd.background,
@@ -4032,13 +4099,11 @@ filechooser placessidebar.sidebar,
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:hover,
       .nautilus-window placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:hover {
         color: #BAC3CF;
-        outline-color: rgba(186, 195, 207, 0.3);
         border-color: rgba(26, 28, 34, 0.4);
         background-color: rgba(119, 127, 151, 0.5); }
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:active,
       .nautilus-window placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:active {
         color: #ffffff;
-        outline-color: rgba(255, 255, 255, 0.3);
         border-color: #2b2e39;
         background-color: #cc575d; }
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:not(:hover):not(:active) > image,
@@ -4114,6 +4179,12 @@ filechooser actionbar {
 .gedit-bottom-panel-paned {
   background-color: #404552; }
 
+.gedit-side-panel-paned > separator {
+  background-image: linear-gradient(to bottom, #2a2d37, #2a2d37); }
+
+.gedit-bottom-panel-paned > separator {
+  background-image: linear-gradient(to bottom, #2b2e39, #2b2e39); }
+
 .gedit-document-panel {
   background-color: #353945; }
   .maximized .gedit-document-panel {
@@ -4136,17 +4207,14 @@ filechooser actionbar {
 
 filechooser actionbar button {
   color: #BAC3CF;
-  outline-color: rgba(186, 195, 207, 0.3);
   border-color: rgba(26, 28, 34, 0.4);
   background-color: rgba(102, 109, 132, 0.4); }
   .caja-side-pane > box button:hover:not(:active), filechooser actionbar button:hover {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: rgba(119, 127, 151, 0.5); }
   filechooser actionbar button:active, filechooser actionbar button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: #cc575d; }
   filechooser actionbar button:disabled {
@@ -4157,17 +4225,16 @@ filechooser actionbar button {
 filechooser actionbar entry {
   color: #BAC3CF;
   border-color: rgba(26, 28, 34, 0.4);
-  background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.4));
-  background-color: transparent; }
+  background-color: rgba(102, 109, 132, 0.4); }
   filechooser actionbar entry image, filechooser actionbar entry image:hover {
     color: inherit; }
   filechooser actionbar entry:focus {
     color: #ffffff;
     border-color: rgba(26, 28, 34, 0.4);
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
   filechooser actionbar entry:disabled {
     color: rgba(186, 195, 207, 0.55);
-    background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.25)); }
+    background-color: rgba(102, 109, 132, 0.25); }
 
 filechooser placessidebar.sidebar scrollbar,
 .nautilus-window placessidebar.sidebar scrollbar, .nemo-window .sidebar scrollbar, .caja-side-pane scrollbar {

--- a/common/gtk-3.0/3.20/gtk-solid-darker.css
+++ b/common/gtk-3.0/3.20/gtk-solid-darker.css
@@ -4,13 +4,11 @@
   -GtkTextView-error-underline-color: #FC4138;
   -GtkScrolledWindow-scrollbar-spacing: 0;
   -GtkToolItemGroup-expander-size: 11;
-  -GtkTreeView-expander-size: 11;
-  -GtkTreeView-horizontal-separator: 4;
   -GtkWidget-text-handle-width: 20;
   -GtkWidget-text-handle-height: 20;
   -GtkDialog-button-spacing: 4;
   -GtkDialog-action-area-border: 0;
-  outline-color: rgba(92, 97, 108, 0.3);
+  outline-color: alpha(currentColor,0.3);
   outline-style: dashed;
   outline-offset: -3px;
   outline-width: 1px;
@@ -107,7 +105,6 @@ popover.background.magnifier, .csd popover.background.osd, .csd popover.backgrou
   border: none;
   background-color: #353945;
   background-clip: padding-box;
-  outline-color: rgba(186, 195, 207, 0.3);
   box-shadow: none; }
 
 @keyframes spin {
@@ -133,8 +130,7 @@ entry {
   transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
   color: #5c616c;
   border-color: #cfd6e6;
-  background-color: #ffffff;
-  background-image: linear-gradient(to bottom, #ffffff); }
+  background-color: #ffffff; }
   entry.search {
     border-radius: 20px; }
   entry image {
@@ -155,51 +151,49 @@ entry {
     background-clip: border-box;
     color: #5c616c;
     border-color: #cc575d;
-    background-color: #ffffff;
-    background-image: linear-gradient(to bottom, #ffffff); }
+    background-color: #ffffff; }
   entry:disabled {
     color: rgba(92, 97, 108, 0.55);
     border-color: rgba(207, 214, 230, 0.55);
-    background-color: rgba(255, 255, 255, 0.55);
-    background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.55)); }
+    background-color: rgba(255, 255, 255, 0.55); }
   entry.warning {
-    color: #ffffff;
+    color: white;
     border-color: #F27835;
-    background-image: linear-gradient(to bottom, #f7ae86); }
+    background-color: #f7ae86; }
     entry.warning image {
-      color: #ffffff; }
+      color: white; }
     entry.warning:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #F27835);
+      color: white;
+      background-color: #F27835;
       box-shadow: none; }
     entry.warning selection, entry.warning selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #F27835; }
   entry.error {
-    color: #ffffff;
+    color: white;
     border-color: #FC4138;
-    background-image: linear-gradient(to bottom, #fd8d88); }
+    background-color: #fd8d88; }
     entry.error image {
-      color: #ffffff; }
+      color: white; }
     entry.error:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138);
+      color: white;
+      background-color: #FC4138;
       box-shadow: none; }
     entry.error selection, entry.error selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
   entry.search-missing {
-    color: #ffffff;
+    color: white;
     border-color: #FC4138;
-    background-image: linear-gradient(to bottom, #fd8d88); }
+    background-color: #fd8d88; }
     entry.search-missing image {
-      color: #ffffff; }
+      color: white; }
     entry.search-missing:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138);
+      color: white;
+      background-color: #FC4138;
       box-shadow: none; }
     entry.search-missing selection, entry.search-missing selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
   entry:drop(active):focus, entry:drop(active) {
     border-color: #F08437;
@@ -207,17 +201,16 @@ entry {
   .osd entry {
     color: #BAC3CF;
     border-color: rgba(26, 28, 34, 0.4);
-    background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.4));
-    background-color: transparent; }
+    background-color: rgba(102, 109, 132, 0.4); }
     .osd entry image, .osd entry image:hover {
       color: inherit; }
     .osd entry:focus {
       color: #ffffff;
       border-color: rgba(26, 28, 34, 0.4);
-      background-image: linear-gradient(to bottom, #cc575d); }
+      background-color: #cc575d; }
     .osd entry:disabled {
       color: rgba(186, 195, 207, 0.55);
-      background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.25)); }
+      background-color: rgba(102, 109, 132, 0.25); }
     .osd entry selection:focus, .osd entry selection {
       color: #cc575d;
       background-color: #ffffff; }
@@ -252,7 +245,6 @@ button {
   border-radius: 3px;
   padding: 2px 6px;
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: #fbfbfc; }
   button separator {
@@ -269,17 +261,18 @@ button {
         transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   button:hover {
     color: #5c616c;
-    outline-color: rgba(92, 97, 108, 0.3);
     border-color: #cfd6e6;
     background-color: white;
     -gtk-icon-effect: highlight; }
   button:active, button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d;
     background-clip: border-box;
     transition-duration: 50ms; }
+    button:active:not(:disabled) label:disabled, button:checked:not(:disabled) label:disabled {
+      color: inherit;
+      opacity: 0.6; }
   button:active {
     color: #5c616c; }
   button:active:hover, button:checked {
@@ -327,7 +320,6 @@ button {
     box-shadow: none; }
   button.osd {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     background-color: #353945;
     border-color: #23262e; }
     button.osd.image-button {
@@ -338,7 +330,6 @@ button {
       color: #cc575d; }
     button.osd:active, button.osd:checked {
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.4);
       background-color: #cc575d; }
     button.osd:disabled {
@@ -347,18 +338,15 @@ button {
       background-color: rgba(102, 109, 132, 0.25); }
   .osd button {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: rgba(102, 109, 132, 0.4); }
     .osd button:hover {
       color: #BAC3CF;
-      outline-color: rgba(186, 195, 207, 0.3);
       border-color: rgba(26, 28, 34, 0.4);
       background-color: rgba(119, 127, 151, 0.5); }
     .osd button:active, .osd button:checked {
       background-clip: padding-box;
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.4);
       background-color: #cc575d; }
     .osd button:disabled {
@@ -372,7 +360,6 @@ button {
       box-shadow: none; }
       .osd button.flat:hover, .osd button.sidebar-button:hover {
         color: #BAC3CF;
-        outline-color: rgba(186, 195, 207, 0.3);
         border-color: rgba(26, 28, 34, 0.4);
         background-color: rgba(119, 127, 151, 0.5); }
       .osd button.flat:disabled, .osd button.sidebar-button:disabled {
@@ -382,7 +369,6 @@ button {
         background-image: none; }
       .osd button.flat:active, .osd button.sidebar-button:active, .osd button.flat:checked, .osd button.sidebar-button:checked {
         color: #ffffff;
-        outline-color: rgba(255, 255, 255, 0.3);
         border-color: rgba(26, 28, 34, 0.4);
         background-color: #cc575d; }
   .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active):not(:only-child),
@@ -390,26 +376,22 @@ button {
     box-shadow: none; }
   button.suggested-action {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
-    background-color: #be3941;
-    border-color: #be3941; }
+    color: white;
+    background-color: #BE3941;
+    border-color: #BE3941; }
     button.suggested-action.flat, button.suggested-action.sidebar-button {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
-      color: #be3941;
-      outline-color: rgba(190, 57, 65, 0.3); }
+      color: #BE3941; }
     button.suggested-action:hover {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #ce5c63;
       border-color: #ce5c63; }
     button.suggested-action:active, button.suggested-action:checked {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #972d34;
       border-color: #972d34; }
     button.suggested-action.flat:disabled, button.suggested-action.sidebar-button:disabled {
@@ -424,26 +406,22 @@ button {
         color: rgba(92, 97, 108, 0.55); }
   button.destructive-action {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #F04A50;
     border-color: #F04A50; }
     button.destructive-action.flat, button.destructive-action.sidebar-button {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
-      color: #F04A50;
-      outline-color: rgba(240, 74, 80, 0.3); }
+      color: #F04A50; }
     button.destructive-action:hover {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #f4797e;
       border-color: #f4797e; }
     button.destructive-action:active, button.destructive-action:checked {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #ec1b22;
       border-color: #ec1b22; }
     button.destructive-action.flat:disabled, button.destructive-action.sidebar-button:disabled {
@@ -483,23 +461,22 @@ button {
     background-position: right 3px, right 4px; }
     .stack-switcher > button.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > image:dir(rtl), button stacksidebar row.needs-attention > label:dir(rtl), stacksidebar button row.needs-attention > label:dir(rtl) {
       background-position: left 3px, left 4px; }
+  button.font separator, button.file separator {
+    background-color: transparent; }
   .inline-toolbar button, .inline-toolbar button:backdrop {
     border-radius: 2px;
     border-width: 1px; }
 
 .inline-toolbar toolbutton > button {
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: #fbfbfc; }
   .inline-toolbar toolbutton > button:hover {
     color: #5c616c;
-    outline-color: rgba(92, 97, 108, 0.3);
     border-color: #cfd6e6;
     background-color: white; }
   .inline-toolbar toolbutton > button:active, .inline-toolbar toolbutton > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d; }
   .inline-toolbar toolbutton > button:disabled {
@@ -576,12 +553,23 @@ button {
 .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
   box-shadow: inset 1px 0 #cfd6e6; }
 
-.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
+  box-shadow: inset 1px 0 rgba(207, 214, 230, 0.5); }
+
 .linked:not(.vertical):not(.path-bar) > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
-.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child) {
+.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:disabled,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked:not(.vertical):not(.path-bar) > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child) {
   box-shadow: none; }
 
 .linked:not(.vertical).path-bar > button + button {
@@ -658,12 +646,23 @@ button {
 .linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
   box-shadow: inset 0 1px #cfd6e6; }
 
-.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
+  box-shadow: inset 0 1px rgba(207, 214, 230, 0.5); }
+
 .linked.vertical > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
-.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child) {
+.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:disabled,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked.vertical > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child) {
   box-shadow: none; }
 
 toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat, toolbar.inline-toolbar toolbutton > button.sidebar-button, .inline-toolbar toolbutton > button.sidebar-button, .linked:not(.vertical) > entry,
@@ -709,7 +708,7 @@ toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > bu
   border-style: solid; }
 
 menuitem.button.flat,
-modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover, .app-notification button.flat, .app-notification button.sidebar-button, .app-notification button.flat:disabled, .app-notification button.sidebar-button:disabled {
+modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover, .app-notification button.flat, .app-notification button.sidebar-button, .app-notification button.flat:disabled, .app-notification button.sidebar-button:disabled, calendar.button {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
@@ -760,16 +759,7 @@ modelbutton.flat arrow.right {
     color: #b8383e; }
     *:selected *:link:active, *:selected button:active:link, *:selected button:active:visited {
       color: #f5dddf; }
-  .info *:link, .info button:link, .info button:visited,
-  .question *:link,
-  .question button:link,
-  .question button:visited,
-  .warning *:link,
-  .warning button:link,
-  .warning button:visited,
-  .error *:link,
-  .error button:link,
-  .error button:visited, *:link:selected, button:selected:link, button:selected:visited, headerbar.selection-mode .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link,
+  infobar.info *:link, infobar.info button:link, infobar.info button:visited, infobar.question *:link, infobar.question button:link, infobar.question button:visited, infobar.warning *:link, infobar.warning button:link, infobar.warning button:visited, infobar.error *:link, infobar.error button:link, infobar.error button:visited, *:link:selected, button:selected:link, button:selected:visited, headerbar.selection-mode .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link,
   *:selected *:link,
   *:selected button:link,
   *:selected button:visited {
@@ -800,6 +790,10 @@ spinbutton:not(.vertical) > button + button {
 spinbutton:not(.vertical) > button:hover:not(:active),
 spinbutton:not(.vertical) > button:hover + button {
   box-shadow: inset 1px 0 #cfd6e6; }
+
+spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover),
+spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled {
+  box-shadow: inset 1px 0 rgba(207, 214, 230, 0.5); }
 
 spinbutton:not(.vertical) > button:first-child:hover:not(:active),
 spinbutton:not(.vertical) > button.up:dir(rtl):hover:not(:active),
@@ -886,7 +880,7 @@ toolbar, .inline-toolbar {
   toolbar:not(.inline-toolbar) .linked > entry, .inline-toolbar:not(.inline-toolbar) .linked > entry {
     margin-right: 0; }
 
-.primary-toolbar {
+.primary-toolbar:not(.libreoffice-toolbar) {
   color: rgba(207, 218, 231, 0.8);
   background-color: #2f343f;
   box-shadow: none;
@@ -1032,22 +1026,21 @@ window.csd > .titlebar:not(headerbar):backdrop {
   box-shadow: none; }
 
 .titlebar:not(headerbar) > separator {
-  background-image: linear-gradient(to top, #262a33); }
+  background-image: linear-gradient(to bottom, #262a33, #262a33); }
 
-.primary-toolbar separator, headerbar separator.titlebutton, .titlebar:not(headerbar) separator.titlebutton {
+.primary-toolbar:not(.libreoffice-toolbar) separator, headerbar separator.titlebutton, .titlebar:not(headerbar) separator.titlebutton {
   min-width: 1px;
   min-height: 1px;
   background: none;
   border-width: 0 1px;
   border-image: linear-gradient(to bottom, rgba(207, 218, 231, 0) 25%, rgba(207, 218, 231, 0.15) 25%, rgba(207, 218, 231, 0.15) 75%, rgba(207, 218, 231, 0) 75%) 0 1/0 1px stretch; }
-  .primary-toolbar separator:backdrop, headerbar separator.titlebutton:backdrop, .titlebar:not(headerbar) separator.titlebutton:backdrop {
+  .primary-toolbar:not(.libreoffice-toolbar) separator:backdrop, headerbar separator.titlebutton:backdrop, .titlebar:not(headerbar) separator.titlebutton:backdrop {
     opacity: 0.6; }
 
 .primary-toolbar entry, headerbar entry {
   color: rgba(207, 218, 231, 0.8);
   border-color: rgba(21, 23, 28, 0.4);
-  background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.4));
-  background-color: transparent; }
+  background-color: rgba(95, 105, 127, 0.4); }
   .primary-toolbar entry image, headerbar entry image, .primary-toolbar entry image:hover, headerbar entry image:hover {
     color: inherit; }
   .primary-toolbar entry:backdrop, headerbar entry:backdrop {
@@ -1055,13 +1048,14 @@ window.csd > .titlebar:not(headerbar):backdrop {
   .primary-toolbar entry:focus, headerbar entry:focus {
     color: #ffffff;
     border-color: transparent;
-    background-image: linear-gradient(to bottom, #cc575d);
+    background-color: #cc575d;
     background-clip: padding-box; }
     .primary-toolbar entry:focus image, headerbar entry:focus image {
       color: #ffffff; }
   .primary-toolbar entry:disabled, headerbar entry:disabled {
     color: rgba(207, 218, 231, 0.35);
-    background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.25)); }
+    border-color: rgba(21, 23, 28, 0.4);
+    background-color: rgba(95, 105, 127, 0.25); }
   .primary-toolbar entry selection:focus, headerbar entry selection:focus {
     background-color: #ffffff;
     color: #cc575d; }
@@ -1070,29 +1064,28 @@ window.csd > .titlebar:not(headerbar):backdrop {
     background-image: none;
     background-color: transparent; }
   .primary-toolbar entry.warning, headerbar entry.warning {
-    color: #ffffff;
+    color: white;
     border-color: rgba(21, 23, 28, 0.4);
-    background-image: linear-gradient(to bottom, #a45d39); }
+    background-color: #a45d39; }
     .primary-toolbar entry.warning:focus, headerbar entry.warning:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #F27835); }
+      color: white;
+      background-color: #F27835; }
     .primary-toolbar entry.warning selection, headerbar entry.warning selection, .primary-toolbar entry.warning selection:focus, headerbar entry.warning selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #F27835; }
   .primary-toolbar entry.error, headerbar entry.error {
-    color: #ffffff;
+    color: white;
     border-color: rgba(21, 23, 28, 0.4);
-    background-image: linear-gradient(to bottom, #aa3c3b); }
+    background-color: #aa3c3b; }
     .primary-toolbar entry.error:focus, headerbar entry.error:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138); }
+      color: white;
+      background-color: #FC4138; }
     .primary-toolbar entry.error selection, headerbar entry.error selection, .primary-toolbar entry.error selection:focus, headerbar entry.error selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
 
 .primary-toolbar button, headerbar button {
   color: rgba(207, 218, 231, 0.8);
-  outline-color: rgba(207, 218, 231, 0.1);
   outline-offset: -3px;
   background-color: rgba(47, 52, 63, 0);
   border-color: rgba(47, 52, 63, 0); }
@@ -1100,12 +1093,10 @@ window.csd > .titlebar:not(headerbar):backdrop {
     opacity: 0.7; }
   .primary-toolbar button:hover, headerbar button:hover {
     color: rgba(207, 218, 231, 0.8);
-    outline-color: rgba(207, 218, 231, 0.1);
     border-color: rgba(21, 23, 28, 0.4);
     background-color: rgba(95, 105, 127, 0.4); }
   .primary-toolbar button:active, headerbar button:active, .primary-toolbar button:checked, headerbar button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d;
     background-clip: padding-box; }
@@ -1133,19 +1124,17 @@ window.csd > .titlebar:not(headerbar):backdrop {
   border-radius: 3px;
   border-style: solid; }
 
-.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
   box-shadow: none; }
 
 .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .linked:not(.vertical).path-bar > button, headerbar .linked:not(.vertical).path-bar > button {
   color: rgba(207, 218, 231, 0.8);
-  outline-color: rgba(207, 218, 231, 0.1);
   border-color: rgba(21, 23, 28, 0.4);
   background-color: rgba(95, 105, 127, 0.4); }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar .linked:not(.vertical).path-bar > button:hover, headerbar .linked:not(.vertical).path-bar > button:hover {
     background-color: rgba(134, 144, 165, 0.4); }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar .linked:not(.vertical).path-bar > button:active, headerbar .linked:not(.vertical).path-bar > button:active, .primary-toolbar .linked:not(.vertical).path-bar > button:checked, headerbar .linked:not(.vertical).path-bar > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d; }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, .primary-toolbar .linked:not(.vertical).path-bar > button:disabled, headerbar .linked:not(.vertical).path-bar > button:disabled {
@@ -1204,26 +1193,22 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar button.suggested-action, headerbar button.suggested-action {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
-  background-color: #be3941;
-  border-color: #be3941; }
+  color: white;
+  background-color: #BE3941;
+  border-color: #BE3941; }
   .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat, .primary-toolbar button.suggested-action.sidebar-button, headerbar button.suggested-action.sidebar-button {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
-    color: #be3941;
-    outline-color: rgba(190, 57, 65, 0.3); }
+    color: #BE3941; }
   .primary-toolbar button.suggested-action:hover, headerbar button.suggested-action:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #ce5c63;
     border-color: #ce5c63; }
   .primary-toolbar button.suggested-action:active, headerbar button.suggested-action:active, .primary-toolbar button.suggested-action:checked, headerbar button.suggested-action:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #972d34;
     border-color: #972d34; }
   .primary-toolbar button.suggested-action.flat:disabled, headerbar button.suggested-action.flat:disabled, .primary-toolbar button.suggested-action.sidebar-button:disabled, headerbar button.suggested-action.sidebar-button:disabled, .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
@@ -1237,26 +1222,22 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar button.destructive-action, headerbar button.destructive-action {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
+  color: white;
   background-color: #F04A50;
   border-color: #F04A50; }
   .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat, .primary-toolbar button.destructive-action.sidebar-button, headerbar button.destructive-action.sidebar-button {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
-    color: #F04A50;
-    outline-color: rgba(240, 74, 80, 0.3); }
+    color: #F04A50; }
   .primary-toolbar button.destructive-action:hover, headerbar button.destructive-action:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #f4797e;
     border-color: #f4797e; }
   .primary-toolbar button.destructive-action:active, headerbar button.destructive-action:active, .primary-toolbar button.destructive-action:checked, headerbar button.destructive-action:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #ec1b22;
     border-color: #ec1b22; }
   .primary-toolbar button.destructive-action.flat:disabled, headerbar button.destructive-action.flat:disabled, .primary-toolbar button.destructive-action.sidebar-button:disabled, headerbar button.destructive-action.sidebar-button:disabled, .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
@@ -1274,7 +1255,6 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar spinbutton:not(.vertical) button, headerbar spinbutton:not(.vertical) button, .primary-toolbar spinbutton:not(.vertical) button:disabled, headerbar spinbutton:not(.vertical) button:disabled {
   color: rgba(207, 218, 231, 0.8);
-  outline-color: rgba(207, 218, 231, 0.1);
   border-color: rgba(21, 23, 28, 0.4);
   background-color: rgba(95, 105, 127, 0.4); }
 
@@ -1283,7 +1263,6 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar spinbutton:not(.vertical) button:active, headerbar spinbutton:not(.vertical) button:active, .primary-toolbar spinbutton:not(.vertical) button:checked, headerbar spinbutton:not(.vertical) button:checked {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   border-color: transparent;
   background-color: #cc575d; }
 
@@ -1294,6 +1273,9 @@ window.csd > .titlebar:not(headerbar):backdrop {
   border-left-style: none; }
 
 .primary-toolbar spinbutton:not(.vertical) > button:hover:not(:active), headerbar spinbutton:not(.vertical) > button:hover:not(:active), .primary-toolbar spinbutton:not(.vertical) > button:hover + button, headerbar spinbutton:not(.vertical) > button:hover + button {
+  box-shadow: inset 1px 0 rgba(21, 23, 28, 0.4); }
+
+.primary-toolbar spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover), headerbar spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover), .primary-toolbar spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled, headerbar spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled {
   box-shadow: inset 1px 0 rgba(21, 23, 28, 0.4); }
 
 .primary-toolbar spinbutton:not(.vertical) > button:first-child:hover:not(:active), headerbar spinbutton:not(.vertical) > button:first-child:hover:not(:active), .primary-toolbar spinbutton:not(.vertical) > entry + button:not(:active):hover, headerbar spinbutton:not(.vertical) > entry + button:not(:active):hover {
@@ -1308,18 +1290,18 @@ window.csd > .titlebar:not(headerbar):backdrop {
 .primary-toolbar combobox > .linked > button.combo, headerbar combobox > .linked > button.combo {
   color: rgba(207, 218, 231, 0.8);
   border-color: rgba(21, 23, 28, 0.4);
-  background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.4));
-  background-color: transparent; }
+  background-color: rgba(95, 105, 127, 0.4); }
   .primary-toolbar combobox > .linked > button.combo image, headerbar combobox > .linked > button.combo image, .primary-toolbar combobox > .linked > button.combo image:hover, headerbar combobox > .linked > button.combo image:hover {
     color: inherit; }
   .primary-toolbar combobox > .linked > button.combo:hover, headerbar combobox > .linked > button.combo:hover {
     color: #ffffff;
     border-color: transparent;
-    background-image: linear-gradient(to bottom, #cc575d);
+    background-color: #cc575d;
     box-shadow: none; }
   .primary-toolbar combobox > .linked > button.combo:disabled, headerbar combobox > .linked > button.combo:disabled {
     color: rgba(207, 218, 231, 0.35);
-    background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.25)); }
+    border-color: rgba(21, 23, 28, 0.4);
+    background-color: rgba(95, 105, 127, 0.25); }
 
 .primary-toolbar combobox > .linked > entry.combo:dir(ltr), headerbar combobox > .linked > entry.combo:dir(ltr) {
   border-right-style: none; }
@@ -1392,13 +1374,15 @@ window.csd > .titlebar:not(headerbar):backdrop {
   padding-right: 4px; }
 
 treeview.view {
-  -GtkTreeView-grid-line-width: 1;
-  -GtkTreeView-grid-line-pattern: '';
-  -GtkTreeView-tree-line-width: 1;
-  -GtkTreeView-tree-line-pattern: '';
-  -GtkTreeView-expander-size: 16;
   border-left-color: rgba(92, 97, 108, 0.15);
   border-top-color: rgba(0, 0, 0, 0.1); }
+  * {
+    -GtkTreeView-horizontal-separator: 4;
+    -GtkTreeView-grid-line-width: 1;
+    -GtkTreeView-grid-line-pattern: '';
+    -GtkTreeView-tree-line-width: 1;
+    -GtkTreeView-tree-line-pattern: '';
+    -GtkTreeView-expander-size: 16; }
   treeview.view acceleditor > label {
     background-color: #cc575d; }
   treeview.view:selected, treeview.view:selected:focus {
@@ -1436,16 +1420,21 @@ treeview.view {
   treeview.view.progressbar, treeview.view.progressbar:focus {
     color: #ffffff;
     border-radius: 3px;
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
     treeview.view.progressbar:selected, treeview.view.progressbar:selected:focus, treeview.view.progressbar:focus:selected, treeview.view.progressbar:focus:selected:focus {
       color: #cc575d;
       box-shadow: none;
-      background-image: linear-gradient(to bottom, #ffffff); }
-  treeview.view.trough, treeview.view.trough:selected, treeview.view.trough:selected:focus {
+      background-color: #ffffff; }
+  treeview.view.trough {
     color: #5c616c;
-    background-image: linear-gradient(to bottom, #cfd6e6);
+    background-color: #cfd6e6;
     border-radius: 3px;
     border-width: 0; }
+    treeview.view.trough:selected, treeview.view.trough:selected:focus {
+      color: #ffffff;
+      background-color: rgba(0, 0, 0, 0.2);
+      border-radius: 3px;
+      border-width: 0; }
   treeview.view header button {
     min-height: 0;
     min-width: 0;
@@ -1835,7 +1824,7 @@ scrollbar {
     min-height: 40px; }
 
 switch {
-  font: 1;
+  font-size: 1px;
   min-width: 52px;
   min-height: 24px;
   background-size: 52px 24px;
@@ -2336,9 +2325,11 @@ frame > border,
   padding: 0;
   border-radius: 0;
   border: 1px solid #dcdfe3; }
-  frame > border.flat,
-  .frame.flat {
-    border-style: none; }
+
+frame.flat > border,
+frame > border.flat,
+.frame.flat {
+  border-style: none; }
 
 scrolledwindow viewport.frame {
   border-style: none; }
@@ -2470,19 +2461,16 @@ row.activatable:selected.has-open-popup, row.activatable:selected:hover {
     border: none; }
   .app-notification button {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: rgba(102, 109, 132, 0.4); }
     .app-notification button.flat, .app-notification button.sidebar-button {
       border-color: rgba(204, 87, 93, 0); }
     .app-notification button:hover {
       color: #BAC3CF;
-      outline-color: rgba(186, 195, 207, 0.3);
       border-color: rgba(26, 28, 34, 0.4);
       background-color: rgba(119, 127, 151, 0.5); }
     .app-notification button:active, .app-notification button:checked {
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.4);
       background-color: #cc575d;
       background-clip: padding-box; }
@@ -2508,24 +2496,16 @@ calendar {
   border-radius: 3px;
   padding: 2px; }
   calendar:selected {
-    background-color: #cc575d;
-    color: #ffffff;
     border-radius: 1.5px; }
   calendar.header {
     color: #5c616c;
-    border: none;
-    border-radius: 0; }
-  calendar.button, calendar.button:focus {
-    color: rgba(92, 97, 108, 0.45);
-    border-color: transparent;
-    background-color: transparent;
-    background-image: none; }
-    calendar.button:hover, calendar.button:focus:hover {
+    border: none; }
+  calendar.button {
+    color: rgba(92, 97, 108, 0.45); }
+    calendar.button:hover {
       color: #5c616c; }
-    calendar.button:disabled, calendar.button:focus:disabled {
-      color: rgba(92, 97, 108, 0.55);
-      background-color: transparent;
-      background-image: none; }
+    calendar.button:disabled {
+      color: rgba(92, 97, 108, 0.55); }
   calendar:indeterminate {
     color: alpha(currentColor,0.55); }
   calendar.highlight {
@@ -2626,7 +2606,7 @@ placessidebar row {
   placessidebar row.sidebar-placeholder-row {
     padding: 0 8px;
     min-height: 2px;
-    background-image: linear-gradient(to top, #F08437);
+    background-image: linear-gradient(to bottom, #F08437, #F08437);
     background-clip: content-box; }
   placessidebar row.sidebar-new-bookmark-row {
     color: #cc575d; }
@@ -2656,15 +2636,15 @@ paned > separator {
   -gtk-icon-source: none;
   border-style: none;
   background-color: transparent;
-  background-image: linear-gradient(to top, #dcdfe3);
+  background-image: linear-gradient(to bottom, #dcdfe3, #dcdfe3);
   background-size: 1px 1px; }
   paned > separator:selected {
-    background-image: linear-gradient(to top, #cc575d); }
+    background-image: linear-gradient(to bottom, #cc575d, #cc575d); }
   paned > separator.wide {
     min-width: 5px;
     min-height: 5px;
     background-color: #F5F6F7;
-    background-image: linear-gradient(to top, #dcdfe3), linear-gradient(to top, #dcdfe3);
+    background-image: linear-gradient(to bottom, #dcdfe3, #dcdfe3), linear-gradient(to bottom, #dcdfe3, #dcdfe3);
     background-size: 1px 1px, 1px 1px; }
 
 paned.horizontal > separator {
@@ -2696,107 +2676,44 @@ paned.vertical > separator {
 
 infobar {
   border-style: none; }
+  infobar.info, infobar.question, infobar.warning, infobar.error {
+    background-color: #cc575d;
+    color: #ffffff;
+    caret-color: currentColor; }
+    infobar.info selection, infobar.question selection, infobar.warning selection, infobar.error selection {
+      color: #cc575d;
+      background-color: #ffffff; }
 
-.info,
-.question,
-.warning,
-.error {
-  background-color: #cc575d;
-  color: #ffffff; }
-  .info label:selected:focus, .info label:selected:hover, .info label:selected,
-  .question label:selected:focus,
-  .question label:selected:hover,
-  .question label:selected,
-  .warning label:selected:focus,
-  .warning label:selected:hover,
-  .warning label:selected,
-  .error label:selected:focus,
-  .error label:selected:hover,
-  .error label:selected {
-    color: #cc575d;
-    background-color: #ffffff; }
-
-.selection-mode.primary-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, .info button,
-.question button,
-.warning button,
-.error button, .nautilus-window .floating-bar button {
+.selection-mode.primary-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, infobar.info button, infobar.question button, infobar.warning button, infobar.error button, .nautilus-window .floating-bar button {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.5); }
 
-row:selected button.flat, row:selected button.sidebar-button, .info button.flat, .info button.sidebar-button,
-.question button.flat,
-.question button.sidebar-button,
-.warning button.flat,
-.warning button.sidebar-button,
-.error button.flat,
-.error button.sidebar-button, .nautilus-window .floating-bar button.flat, .nautilus-window .floating-bar button.sidebar-button {
+row:selected button.flat, row:selected button.sidebar-button, infobar.info button.flat, infobar.info button.sidebar-button, infobar.question button.flat, infobar.question button.sidebar-button, infobar.warning button.flat, infobar.warning button.sidebar-button, infobar.error button.flat, infobar.error button.sidebar-button, .nautilus-window .floating-bar button.flat, .nautilus-window .floating-bar button.sidebar-button {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0); }
-  .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, row:selected button.flat:disabled, row:selected button.sidebar-button:disabled, .info button.flat:disabled, .info button.sidebar-button:disabled,
-  .question button.flat:disabled,
-  .question button.sidebar-button:disabled,
-  .warning button.flat:disabled,
-  .warning button.sidebar-button:disabled,
-  .error button.flat:disabled,
-  .error button.sidebar-button:disabled, .nautilus-window .floating-bar button.flat:disabled, .nautilus-window .floating-bar button.sidebar-button:disabled, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled label, row:selected button.sidebar-button:disabled label, .info button.flat:disabled label, .info button.sidebar-button:disabled label,
-  .question button.flat:disabled label,
-  .question button.sidebar-button:disabled label,
-  .warning button.flat:disabled label,
-  .warning button.sidebar-button:disabled label,
-  .error button.flat:disabled label,
-  .error button.sidebar-button:disabled label, .nautilus-window .floating-bar button.flat:disabled label, .nautilus-window .floating-bar button.sidebar-button:disabled label {
+  .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, row:selected button.flat:disabled, row:selected button.sidebar-button:disabled, infobar.info button.flat:disabled, infobar.info button.sidebar-button:disabled, infobar.question button.flat:disabled, infobar.question button.sidebar-button:disabled, infobar.warning button.flat:disabled, infobar.warning button.sidebar-button:disabled, infobar.error button.flat:disabled, infobar.error button.sidebar-button:disabled, .nautilus-window .floating-bar button.flat:disabled, .nautilus-window .floating-bar button.sidebar-button:disabled, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled label, row:selected button.sidebar-button:disabled label, infobar.info button.flat:disabled label, infobar.info button.sidebar-button:disabled label, infobar.question button.flat:disabled label, infobar.question button.sidebar-button:disabled label, infobar.warning button.flat:disabled label, infobar.warning button.sidebar-button:disabled label, infobar.error button.flat:disabled label, infobar.error button.sidebar-button:disabled label, .nautilus-window .floating-bar button.flat:disabled label, .nautilus-window .floating-bar button.sidebar-button:disabled label {
     color: rgba(255, 255, 255, 0.4); }
 
-row:selected button:hover, .info button:hover,
-.question button:hover,
-.warning button:hover,
-.error button:hover, .nautilus-window .floating-bar button:hover {
+row:selected button:hover, infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover, .nautilus-window .floating-bar button:hover {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   background-color: rgba(255, 255, 255, 0.2);
   border-color: rgba(255, 255, 255, 0.8); }
 
-.selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, .info button:active,
-.question button:active,
-.warning button:active,
-.error button:active, .nautilus-window .floating-bar button:active, .selection-mode.primary-toolbar button:hover:active, headerbar.selection-mode button:hover:active, .selection-mode.primary-toolbar button:hover:checked, headerbar.selection-mode button:hover:checked, row:selected button:active:hover, .info button:active:hover,
-.question button:active:hover,
-.warning button:active:hover,
-.error button:active:hover, .nautilus-window .floating-bar button:active:hover, row:selected button:checked, .info button:checked,
-.question button:checked,
-.warning button:checked,
-.error button:checked, .nautilus-window .floating-bar button:checked {
+.selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, .nautilus-window .floating-bar button:active, .selection-mode.primary-toolbar button:hover:active, headerbar.selection-mode button:hover:active, .selection-mode.primary-toolbar button:hover:checked, headerbar.selection-mode button:hover:checked, row:selected button:active:hover, infobar.info button:active:hover, infobar.question button:active:hover, infobar.warning button:active:hover, infobar.error button:active:hover, .nautilus-window .floating-bar button:active:hover, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked, .nautilus-window .floating-bar button:checked {
   color: #cc575d;
-  outline-color: rgba(204, 87, 93, 0.3);
   background-color: #ffffff;
   border-color: #ffffff; }
 
-row:selected button:disabled, .info button:disabled,
-.question button:disabled,
-.warning button:disabled,
-.error button:disabled, .nautilus-window .floating-bar button:disabled {
+row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, .nautilus-window .floating-bar button:disabled {
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.4); }
-  row:selected button:disabled, .info button:disabled,
-  .question button:disabled,
-  .warning button:disabled,
-  .error button:disabled, .nautilus-window .floating-bar button:disabled, row:selected button:disabled label, .info button:disabled label,
-  .question button:disabled label,
-  .warning button:disabled label,
-  .error button:disabled label, .nautilus-window .floating-bar button:disabled label {
+  row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, .nautilus-window .floating-bar button:disabled, row:selected button:disabled label, infobar.info button:disabled label, infobar.question button:disabled label, infobar.warning button:disabled label, infobar.error button:disabled label, .nautilus-window .floating-bar button:disabled label {
     color: rgba(255, 255, 255, 0.5); }
-  .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, row:selected button:disabled:active, .info button:disabled:active,
-  .question button:disabled:active,
-  .warning button:disabled:active,
-  .error button:disabled:active, .nautilus-window .floating-bar button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:checked, .info button:disabled:checked,
-  .question button:disabled:checked,
-  .warning button:disabled:checked,
-  .error button:disabled:checked, .nautilus-window .floating-bar button:disabled:checked {
+  .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, .nautilus-window .floating-bar button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked, .nautilus-window .floating-bar button:disabled:checked {
     color: #cc575d;
     background-color: rgba(255, 255, 255, 0.5);
     border-color: rgba(255, 255, 255, 0.4); }
@@ -2871,12 +2788,10 @@ colorswatch#add-color-button {
   border-style: solid;
   border-width: 1px;
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: #fbfbfc; }
   colorswatch#add-color-button:hover {
     color: #5c616c;
-    outline-color: rgba(92, 97, 108, 0.3);
     border-color: #cfd6e6;
     background-color: white; }
   colorswatch#add-color-button overlay {
@@ -2900,7 +2815,6 @@ colorchooser .popover.osd {
 
 .scale-popup button:hover {
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: white; }
 
@@ -2909,13 +2823,14 @@ popover.background.touch-selection, .csd popover.background.touch-selection {
   font: initial; }
 
 .monospace {
-  font: Monospace; }
+  font-family: Monospace; }
 
 button.circular, button.nautilus-circular-button.image-button,
 button.circular-button {
   padding: 0;
-  min-width: 26px;
-  min-height: 26px;
+  min-width: 16px;
+  min-height: 24px;
+  padding: 2px 6px;
   border-radius: 50%;
   -gtk-outline-radius: 50%; }
   button.circular label, button.nautilus-circular-button.image-button label,
@@ -2993,14 +2908,12 @@ headerbar button.titlebutton,
   headerbar button.titlebutton:hover,
   .titlebar button.titlebutton:hover {
     color: rgba(207, 218, 231, 0.8);
-    outline-color: rgba(207, 218, 231, 0.1);
     border-color: rgba(21, 23, 28, 0.4);
     background-color: rgba(95, 105, 127, 0.4); }
   headerbar button.titlebutton:active, headerbar button.titlebutton:checked,
   .titlebar button.titlebutton:active,
   .titlebar button.titlebutton:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d; }
   headerbar button.titlebutton.close, headerbar button.titlebutton.maximize, headerbar button.titlebutton.minimize,
@@ -3062,7 +2975,7 @@ textview text selection, flowbox flowboxchild:selected, entry selection:focus, e
 modelbutton.flat:active,
 modelbutton.flat:active arrow,
 modelbutton.flat:selected,
-modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
+modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, calendar:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
 .nautilus-window placessidebar.sidebar row.sidebar-row.has-open-popup:selected,
 .nautilus-window placessidebar.sidebar row.sidebar-row:selected,
 .nautilus-window placessidebar.sidebar row.sidebar-row:selected:hover,
@@ -3076,20 +2989,19 @@ modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:
   modelbutton.flat:active,
   modelbutton.flat:active arrow,
   modelbutton.flat:selected,
-  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
+  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, calendar:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
   .nautilus-window placessidebar.sidebar row.sidebar-row.has-open-popup:selected,
   .nautilus-window placessidebar.sidebar row.sidebar-row:selected,
   .nautilus-window placessidebar.sidebar row.sidebar-row:selected:hover,
   .nautilus-window placessidebar.sidebar row.sidebar-row:active:hover {
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3); }
+    color: #ffffff; }
     row:selected label:disabled, label:disabled:selected, .view:disabled:selected, iconview:disabled:selected, iconview:disabled:selected:focus, .view text:disabled:selected, iconview text:disabled:selected,
     textview text:disabled:selected, iconview text selection:disabled:focus, .view text selection:disabled, iconview text selection:disabled,
     textview text selection:disabled, flowbox flowboxchild:disabled:selected, label:disabled selection, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
     modelbutton.flat:disabled:active,
     modelbutton.flat:active arrow:disabled,
     modelbutton.flat:disabled:selected,
-    modelbutton.flat:selected arrow:disabled, treeview.view:disabled:selected:focus, row:disabled:selected, .nemo-window .nemo-window-pane widget.entry:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:active:hover,
+    modelbutton.flat:selected arrow:disabled, treeview.view:disabled:selected:focus, row:disabled:selected, calendar:disabled:selected, .nemo-window .nemo-window-pane widget.entry:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:active:hover,
     .nautilus-window placessidebar.sidebar row.sidebar-row:disabled:selected,
     .nautilus-window placessidebar.sidebar row.sidebar-row:disabled:active:hover {
       color: #e6abae; }
@@ -3098,10 +3010,12 @@ modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:
 terminal-window notebook > header.top > tabs > tab:checked {
   box-shadow: inset 0 -1px #dcdfe3; }
 
-terminal-window notebook > header.top {
+terminal-window notebook > header.top,
+.mate-terminal notebook > header.top {
   padding-top: 3px;
   box-shadow: inset 0 1px #262a33, inset 0 -1px #dcdfe3; }
-  terminal-window notebook > header.top button {
+  terminal-window notebook > header.top button,
+  .mate-terminal notebook > header.top button {
     padding: 0;
     min-width: 24px;
     min-height: 24px; }
@@ -3110,7 +3024,7 @@ terminal-window notebook > header.top {
   border-radius: 2px; }
 
 .nautilus-desktop.nautilus-canvas-item, .nemo-desktop.nemo-canvas-item, .caja-desktop {
-  color: #ffffff;
+  color: white;
   text-shadow: 1px 1px rgba(0, 0, 0, 0.6); }
   .nautilus-desktop.nautilus-canvas-item:active, .nemo-desktop.nemo-canvas-item:active, .caja-desktop:active {
     color: #5c616c; }
@@ -3153,12 +3067,10 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
 @keyframes needs_attention_keyframes {
   0% {
     color: rgba(207, 218, 231, 0.8);
-    outline-color: rgba(207, 218, 231, 0.1);
     border-color: rgba(21, 23, 28, 0.4);
     background-color: rgba(95, 105, 127, 0.4); }
   100% {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d; } }
 
@@ -3168,6 +3080,17 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
 .nautilus-operations-button-needs-attention-multiple {
   animation: needs_attention_keyframes 3s ease-in-out;
   animation-iteration-count: 3; }
+
+.conflict-row.activatable, .conflict-row.activatable:active {
+  color: white;
+  background-color: #FC4138; }
+
+.conflict-row.activatable:hover {
+  background-color: #fd716a; }
+
+.conflict-row.activatable:selected {
+  color: #ffffff;
+  background-color: #cc575d; }
 
 .nemo-window .nemo-places-sidebar.frame {
   border-width: 0; }
@@ -3180,12 +3103,10 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
   border-radius: 3px;
   color: #5c616c;
   border-color: #cc575d;
-  background-color: #ffffff;
-  background-image: linear-gradient(to bottom, #ffffff); }
+  background-color: #ffffff; }
 
 .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button {
   color: rgba(207, 218, 231, 0.8);
-  outline-color: rgba(207, 218, 231, 0.1);
   border-color: rgba(21, 23, 28, 0.4);
   background-color: rgba(95, 105, 127, 0.4); }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:not(:last-child):not(:only-child) {
@@ -3194,7 +3115,6 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
     background-color: rgba(134, 144, 165, 0.4); }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:active, .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #cc575d; }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:disabled {
@@ -3288,6 +3208,27 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
   margin: 2px;
   padding: 2px; }
 
+.gedit-map-frame border {
+  border-color: rgba(0, 0, 0, 0.3);
+  border-width: 0; }
+  .gedit-map-frame border:dir(ltr) {
+    border-left-width: 1px; }
+  .gedit-map-frame border:dir(rtl) {
+    border-right-width: 1px; }
+
+.pluma-window statusbar frame > border {
+  border: none; }
+
+.pluma-window notebook > stack scrolledwindow {
+  border-width: 0 0 1px 0; }
+
+#pluma-status-combo-button {
+  min-height: 0;
+  padding: 0;
+  border-top: none;
+  border-bottom: none;
+  border-radius: 0; }
+
 .gb-search-entry-occurrences-tag {
   background: none; }
 
@@ -3316,6 +3257,8 @@ pillbox {
   color: #ffffff;
   background-color: #cc575d;
   border-radius: 3px; }
+  pillbox:disabled label {
+    color: rgba(255, 255, 255, 0.5); }
 
 docktabstrip {
   padding: 0 6px;
@@ -3348,6 +3291,62 @@ dockoverlayedge {
   dockoverlayedge.left-edge tab:checked,
   dockoverlayedge.right-edge tab:checked {
     border-width: 1px 0; }
+
+popover.messagepopover.background {
+  padding: 0; }
+
+popover.messagepopover .popover-content-area {
+  margin: 16px; }
+
+popover.messagepopover .popover-action-area {
+  margin: 8px; }
+  popover.messagepopover .popover-action-area button:not(:first-child):not(:last-child) {
+    margin: 0 4px; }
+
+popover.popover-selector {
+  padding: 0; }
+  popover.popover-selector list row {
+    padding: 5px 0; }
+  popover.popover-selector list row image {
+    margin-left: 3px;
+    margin-right: 10px; }
+
+entry.search.preferences-search {
+  border: none;
+  border-right: 1px solid #dcdfe3;
+  border-bottom: 1px solid #dcdfe3;
+  border-radius: 0; }
+
+preferences stacksidebar.sidebar list {
+  background-image: linear-gradient(to bottom, #ffffff, #ffffff); }
+
+preferences stacksidebar.sidebar list separator {
+  background-color: transparent; }
+
+devhelppanel entry:focus,
+symboltreepanel entry:focus {
+  border-color: #dcdfe3; }
+
+button.run-arrow-button {
+  min-width: 12px; }
+
+omnibar.linked > entry:not(:only-child) {
+  border-style: solid;
+  border-radius: 3px;
+  margin-left: 1px;
+  margin-right: 1px; }
+
+gstyleslidein #scale_box button.toggle:checked,
+gstyleslidein #strings_controls button.toggle:checked,
+gstyleslidein #palette_controls button.toggle:checked,
+gstyleslidein #components_controls button.toggle:checked {
+  color: #5c616c; }
+
+configurationview entry.flat {
+  background: none; }
+
+configurationview list {
+  border-width: 0; }
 
 .documents-scrolledwin.frame {
   border-width: 0; }
@@ -3396,46 +3395,119 @@ button.documents-favorite:active:hover {
   opacity: 0.0;
   transition: opacity 0.2s ease-out; }
 
+.tweak-categories,
+.tweak-category:not(:selected):not(:hover) {
+  background-image: linear-gradient(to bottom, #ffffff, #ffffff); }
+
 .tr-workarea undershoot,
 .tr-workarea overshoot {
   border-color: transparent; }
 
-.gnome-panel-menu-bar, .gnome-panel-menu-bar menubar,
-.mate-panel-menu-bar,
-.mate-panel-menu-bar menubar {
+.atril-window .primary-toolbar toolbar, .atril-window .primary-toolbar .inline-toolbar {
+  background: none; }
+
+#gf-bubble, #gf-bubble.solid,
+#gf-osd-window,
+#gf-osd-window.solid,
+#gf-input-source-popup,
+#gf-input-source-popup.solid,
+#gf-candidate-popup,
+#gf-candidate-popup.solid {
+  color: #cfd5de;
+  background-color: #353945;
+  border: 1px solid #23262e;
+  border-radius: 2px; }
+
+#gf-bubble levelbar block.low, #gf-bubble levelbar block.high, #gf-bubble levelbar block.full,
+#gf-osd-window levelbar block.low,
+#gf-osd-window levelbar block.high,
+#gf-osd-window levelbar block.full,
+#gf-input-source-popup levelbar block.low,
+#gf-input-source-popup levelbar block.high,
+#gf-input-source-popup levelbar block.full,
+#gf-candidate-popup levelbar block.low,
+#gf-candidate-popup levelbar block.high,
+#gf-candidate-popup levelbar block.full {
+  background-color: #cc575d;
+  border-color: #cc575d; }
+
+#gf-bubble levelbar block.empty,
+#gf-osd-window levelbar block.empty,
+#gf-input-source-popup levelbar block.empty,
+#gf-candidate-popup levelbar block.empty {
+  background-color: #2a2d37; }
+
+#gf-bubble levelbar trough,
+#gf-osd-window levelbar trough,
+#gf-input-source-popup levelbar trough,
+#gf-candidate-popup levelbar trough {
+  background: none; }
+
+#gf-input-source {
+  min-height: 32px;
+  min-width: 40px; }
+  #gf-input-source:selected {
+    color: #ffffff;
+    background-color: #cc575d;
+    border-radius: 2px; }
+
+gf-candidate-box label {
+  padding: 3px; }
+
+gf-candidate-box:hover, gf-candidate-box:selected {
+  color: #ffffff;
+  background-color: #cc575d;
+  border-radius: 2px; }
+
+MsdOsdWindow.background.osd {
+  border-radius: 2px;
+  border: 1px solid #23262e; }
+  MsdOsdWindow.background.osd .progressbar {
+    background-color: #cc575d;
+    border: none;
+    border-color: red;
+    border-radius: 5px; }
+  MsdOsdWindow.background.osd .trough {
+    background-color: #2a2d37;
+    border: none;
+    border-radius: 5px; }
+
+.mate-panel-menu-bar, .mate-panel-menu-bar menubar,
+panel-toplevel.background,
+panel-toplevel.background menubar {
   background-color: #2b2e37; }
 
-.gnome-panel-menu-bar menubar,
-.gnome-panel-menu-bar #PanelApplet label,
-.gnome-panel-menu-bar #PanelApplet image,
 .mate-panel-menu-bar menubar,
 .mate-panel-menu-bar #PanelApplet label,
-.mate-panel-menu-bar #PanelApplet image {
+.mate-panel-menu-bar #PanelApplet image,
+panel-toplevel.background menubar,
+panel-toplevel.background #PanelApplet label,
+panel-toplevel.background #PanelApplet image {
   color: #BAC3CF; }
 
-.gnome-panel-menu-bar button label, .gnome-panel-menu-bar button image,
-.gnome-panel-menu-bar #tasklist-button label,
-.gnome-panel-menu-bar #tasklist-button image,
-.mate-panel-menu-bar button label,
-.mate-panel-menu-bar button image,
+.mate-panel-menu-bar button label, .mate-panel-menu-bar button image,
 .mate-panel-menu-bar #tasklist-button label,
-.mate-panel-menu-bar #tasklist-button image {
+.mate-panel-menu-bar #tasklist-button image,
+panel-toplevel.background button label,
+panel-toplevel.background button image,
+panel-toplevel.background #tasklist-button label,
+panel-toplevel.background #tasklist-button image {
   color: inherit; }
 
-.gnome-panel-menu-bar .wnck-pager,
-.mate-panel-menu-bar .wnck-pager {
+.mate-panel-menu-bar .wnck-pager,
+panel-toplevel.background .wnck-pager {
   color: #5d6268;
   background-color: #14161b; }
-  .gnome-panel-menu-bar .wnck-pager:hover,
-  .mate-panel-menu-bar .wnck-pager:hover {
+  .mate-panel-menu-bar .wnck-pager:hover,
+  panel-toplevel.background .wnck-pager:hover {
     background-color: #363a46; }
-  .gnome-panel-menu-bar .wnck-pager:selected,
-  .mate-panel-menu-bar .wnck-pager:selected {
+  .mate-panel-menu-bar .wnck-pager:selected,
+  panel-toplevel.background .wnck-pager:selected {
     color: #e4a5a8;
     background-color: #cc575d; }
 
-.gnome-panel-menu-bar na-tray-applet,
-.mate-panel-menu-bar na-tray-applet {
+.mate-panel-menu-bar na-tray-applet,
+panel-toplevel.background na-tray-applet {
   -NaTrayApplet-icon-padding: 0;
   -NaTrayApplet-icon-size: 16px; }
 
@@ -3453,26 +3525,32 @@ button.documents-favorite:active:hover {
     color: #d8dde4;
     background-color: rgba(0, 0, 0, 0.17); }
   #tasklist-button:checked {
-    color: #ffffff;
+    color: white;
     background-color: rgba(0, 0, 0, 0.25);
     box-shadow: inset 0 -2px #cc575d; }
 
-.gnome-panel-menu-bar button:not(#tasklist-button),
-.mate-panel-menu-bar button:not(#tasklist-button), .xfce4-panel.panel button.flat, .xfce4-panel.panel button.sidebar-button {
+.mate-panel-menu-bar button:not(#tasklist-button),
+panel-toplevel.background button:not(#tasklist-button), .xfce4-panel.panel button.flat, .xfce4-panel.panel button.sidebar-button {
   color: #BAC3CF;
   border-radius: 0;
   border: none;
   background-color: rgba(43, 46, 55, 0); }
-  .gnome-panel-menu-bar button:hover:not(#tasklist-button),
-  .mate-panel-menu-bar button:hover:not(#tasklist-button), .xfce4-panel.panel button.flat:hover, .xfce4-panel.panel button.sidebar-button:hover {
+  .mate-panel-menu-bar button:hover:not(#tasklist-button),
+  panel-toplevel.background button:hover:not(#tasklist-button), .xfce4-panel.panel button.flat:hover, .xfce4-panel.panel button.sidebar-button:hover {
     border: none;
     background-color: #414654; }
-  .gnome-panel-menu-bar button:active:not(#tasklist-button),
-  .mate-panel-menu-bar button:active:not(#tasklist-button), .xfce4-panel.panel button.flat:active, .xfce4-panel.panel button.sidebar-button:active, .gnome-panel-menu-bar button:checked:not(#tasklist-button),
-  .mate-panel-menu-bar button:checked:not(#tasklist-button), .xfce4-panel.panel button.flat:checked, .xfce4-panel.panel button.sidebar-button:checked {
+  .mate-panel-menu-bar button:active:not(#tasklist-button),
+  panel-toplevel.background button:active:not(#tasklist-button), .xfce4-panel.panel button.flat:active, .xfce4-panel.panel button.sidebar-button:active, .mate-panel-menu-bar button:checked:not(#tasklist-button),
+  panel-toplevel.background button:checked:not(#tasklist-button), .xfce4-panel.panel button.flat:checked, .xfce4-panel.panel button.sidebar-button:checked {
     color: #ffffff;
     border: none;
     background-color: #cc575d; }
+    .mate-panel-menu-bar button:active:not(#tasklist-button) label,
+    panel-toplevel.background button:active:not(#tasklist-button) label, .xfce4-panel.panel button.flat:active label, .xfce4-panel.panel button.sidebar-button:active label, .mate-panel-menu-bar button:active:not(#tasklist-button) image,
+    panel-toplevel.background button:active:not(#tasklist-button) image, .xfce4-panel.panel button.flat:active image, .xfce4-panel.panel button.sidebar-button:active image, .mate-panel-menu-bar button:checked:not(#tasklist-button) label,
+    panel-toplevel.background button:checked:not(#tasklist-button) label, .xfce4-panel.panel button.flat:checked label, .xfce4-panel.panel button.sidebar-button:checked label, .mate-panel-menu-bar button:checked:not(#tasklist-button) image,
+    panel-toplevel.background button:checked:not(#tasklist-button) image, .xfce4-panel.panel button.flat:checked image, .xfce4-panel.panel button.sidebar-button:checked image {
+      color: inherit; }
 
 .nautilus-window .floating-bar {
   padding: 1px;
@@ -3494,17 +3572,17 @@ button.documents-favorite:active:hover {
   padding-right: 4px;
   color: rgba(207, 218, 231, 0.8);
   border-color: rgba(21, 23, 28, 0.4);
-  background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.4));
-  background-color: transparent; }
+  background-color: rgba(95, 105, 127, 0.4); }
   .marlin-pathbar.pathbar image, .marlin-pathbar.pathbar image:hover {
     color: inherit; }
   .marlin-pathbar.pathbar:focus {
     color: #ffffff;
     border-color: transparent;
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
   .marlin-pathbar.pathbar:disabled {
     color: rgba(207, 218, 231, 0.35);
-    background-image: linear-gradient(to bottom, rgba(95, 105, 127, 0.25)); }
+    border-color: rgba(21, 23, 28, 0.4);
+    background-color: rgba(95, 105, 127, 0.25); }
   .marlin-pathbar.pathbar:active, .marlin-pathbar.pathbar:checked {
     color: #cc575d; }
 
@@ -3512,7 +3590,7 @@ button.documents-favorite:active:hover {
   border: 1px solid rgba(0, 0, 0, 0.35);
   border-radius: 3px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  background-image: linear-gradient(to bottom, white);
+  background-image: linear-gradient(to bottom, white, white);
   background-color: transparent; }
   .gala-notification .title, .gala-notification .label {
     color: #5c616c; }
@@ -3579,24 +3657,25 @@ UnityDecoration {
   -UnityDecoration-title-indent: 10px;
   -UnityDecoration-title-fade: 35px;
   -UnityDecoration-title-alignment: 0.0; }
-  UnityDecoration.top {
+  UnityDecoration .top {
     border: 1px solid #20232b;
     border-bottom-width: 0;
     border-radius: 4px 4px 0 0;
     padding: 1px 6px 0 6px;
-    background-image: linear-gradient(to bottom, #2f343f);
+    background-image: linear-gradient(to bottom, #2f343f, #2f343f);
     color: rgba(207, 218, 231, 0.8);
     box-shadow: inset 0 1px #363b48; }
-    UnityDecoration.top:backdrop {
+    UnityDecoration .top:backdrop {
       border-bottom-width: 0;
       color: rgba(207, 218, 231, 0.5); }
-  UnityDecoration.left, UnityDecoration.right, UnityDecoration.bottom, UnityDecoration.left:backdrop, UnityDecoration.right:backdrop, UnityDecoration.bottom:backdrop {
+  UnityDecoration .left, UnityDecoration .right, UnityDecoration .bottom,
+  UnityDecoration .left:backdrop, UnityDecoration .right:backdrop, UnityDecoration .bottom:backdrop {
     background-color: transparent;
-    background-image: linear-gradient(to bottom, #20232b); }
+    background-image: linear-gradient(to bottom, #20232b, #20232b); }
 
 UnityPanelWidget,
 .unity-panel {
-  background-image: linear-gradient(to bottom, #2f343f);
+  background-image: linear-gradient(to bottom, #2f343f, #2f343f);
   color: #f6f7f9;
   box-shadow: none; }
   UnityPanelWidget:backdrop,
@@ -3607,7 +3686,7 @@ UnityPanelWidget,
 .unity-panel.menubar .menuitem *:hover {
   border-radius: 0;
   color: #ffffff;
-  background-image: linear-gradient(to bottom, #cc575d);
+  background-image: linear-gradient(to bottom, #cc575d, #cc575d);
   border-bottom: none; }
 
 .lightdm.menu {
@@ -3800,7 +3879,7 @@ GraniteWidgetsWelcome {
 
 GraniteWidgetsWelcome label {
   color: #a9acb2;
-  font: open sans 11;
+  font-size: 11px;
   text-shadow: none; }
 
 GraniteWidgetsWelcome .h1,
@@ -3820,7 +3899,7 @@ GraniteWidgetsPopOver {
   margin: 0; }
 
 .popover_bg {
-  background-image: linear-gradient(to bottom, #ffffff);
+  background-image: linear-gradient(to bottom, #ffffff, #ffffff);
   border: 1px solid rgba(0, 0, 0, 0.3); }
 
 GraniteWidgetsPopOver .sidebar.view, GraniteWidgetsPopOver iconview.sidebar,
@@ -3831,13 +3910,13 @@ GraniteWidgetsXsEntry entry {
   padding: 4px; }
 
 .h1 {
-  font: open sans 24px; }
+  font-size: 24px; }
 
 .h2 {
-  font: open sans light 18px; }
+  font-size: 18px; }
 
 .h3 {
-  font: open sans 11px; }
+  font-size: 11px; }
 
 .h4,
 .category-label {
@@ -3854,24 +3933,25 @@ GtkListBox .h4 {
 #panel_window {
   background-color: #2b2e37;
   color: #BAC3CF;
-  font: bold;
+  font-weight: bold;
   box-shadow: inset 0 -1px #1b1d23; }
-  #panel_window menubar,
-  #panel_window menubar > menuitem {
-    background-color: transparent;
-    color: #BAC3CF;
-    font: bold; }
+  #panel_window menubar {
+    padding-left: 5px; }
+    #panel_window menubar, #panel_window menubar > menuitem {
+      background-color: transparent;
+      color: #BAC3CF;
+      font-weight: bold; }
   #panel_window menubar menuitem:disabled {
     color: rgba(186, 195, 207, 0.5); }
     #panel_window menubar menuitem:disabled label {
       color: inherit; }
   #panel_window menubar menu > menuitem {
-    font: normal; }
+    font-weight: normal; }
 
 #login_window,
 #shutdown_dialog,
 #restart_dialog {
-  font: normal;
+  font-weight: normal;
   border-style: none;
   background-color: transparent;
   color: #5c616c; }
@@ -3886,17 +3966,14 @@ GtkListBox .h4 {
 
 #content_frame button {
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: #fbfbfc; }
   #content_frame button:hover {
     color: #5c616c;
-    outline-color: rgba(92, 97, 108, 0.3);
     border-color: #cfd6e6;
     background-color: white; }
   #content_frame button:active, #content_frame button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d; }
   #content_frame button:disabled {
@@ -3918,17 +3995,14 @@ GtkListBox .h4 {
 
 #buttonbox_frame button {
   color: #BAC3CF;
-  outline-color: rgba(186, 195, 207, 0.3);
   border-color: rgba(26, 28, 34, 0.4);
   background-color: rgba(102, 109, 132, 0.4); }
   #buttonbox_frame button:hover {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: rgba(119, 127, 151, 0.5); }
   #buttonbox_frame button:active, #buttonbox_frame button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: #cc575d; }
   #buttonbox_frame button:disabled {
@@ -3938,9 +4012,9 @@ GtkListBox .h4 {
 
 #login_window #user_combobox {
   color: #5c616c;
-  font: 13px; }
+  font-size: 13px; }
   #login_window #user_combobox menu {
-    font: normal; }
+    font-weight: normal; }
 
 #user_image {
   padding: 3px;
@@ -3948,55 +4022,49 @@ GtkListBox .h4 {
 
 #shutdown_button.button {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
+  color: green;
   background-color: #F04A50;
   border-color: #F04A50; }
   #shutdown_button.button:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #f4797e;
     border-color: #f4797e; }
   #shutdown_button.button:active, #shutdown_button.button:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #ec1b22;
     border-color: #ec1b22; }
 
 #restart_button.button {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
-  background-color: #be3941;
-  border-color: #be3941; }
+  color: green;
+  background-color: #BE3941;
+  border-color: #BE3941; }
   #restart_button.button:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #ce5c63;
     border-color: #ce5c63; }
   #restart_button.button:active, #restart_button.button:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #972d34;
     border-color: #972d34; }
 
 #greeter_infobar {
   border-bottom-width: 0;
-  font: bold; }
+  font-weight: bold; }
 
 .nautilus-window paned > separator {
-  background-image: linear-gradient(to top, #353945); }
+  background-image: linear-gradient(to bottom, #353945, #353945); }
   .nautilus-window paned > separator:dir(ltr) {
     margin-left: -1px; }
   .nautilus-window paned > separator:dir(rtl) {
     margin-right: -1px; }
 
 filechooser paned > separator {
-  background-image: linear-gradient(to top, #353945); }
+  background-image: linear-gradient(to bottom, #353945, #353945); }
 
 filechooser.csd.background, filechooser placessidebar list,
 .nautilus-window.csd.background,
@@ -4034,13 +4102,11 @@ filechooser placessidebar.sidebar,
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:hover,
       .nautilus-window placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:hover {
         color: #BAC3CF;
-        outline-color: rgba(186, 195, 207, 0.3);
         border-color: rgba(26, 28, 34, 0.4);
         background-color: rgba(119, 127, 151, 0.5); }
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:active,
       .nautilus-window placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:active {
         color: #ffffff;
-        outline-color: rgba(255, 255, 255, 0.3);
         border-color: #cc575d;
         background-color: #cc575d; }
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:not(:hover):not(:active) > image,
@@ -4116,6 +4182,12 @@ filechooser actionbar {
 .gedit-bottom-panel-paned {
   background-color: #ffffff; }
 
+.gedit-side-panel-paned > separator {
+  background-image: linear-gradient(to bottom, #353945, #353945); }
+
+.gedit-bottom-panel-paned > separator {
+  background-image: linear-gradient(to bottom, #dcdfe3, #dcdfe3); }
+
 .gedit-document-panel {
   background-color: #353945; }
   .maximized .gedit-document-panel {
@@ -4138,17 +4210,14 @@ filechooser actionbar {
 
 filechooser actionbar button {
   color: #BAC3CF;
-  outline-color: rgba(186, 195, 207, 0.3);
   border-color: rgba(26, 28, 34, 0.4);
   background-color: rgba(102, 109, 132, 0.4); }
   .caja-side-pane > box button:hover:not(:active), filechooser actionbar button:hover {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: rgba(119, 127, 151, 0.5); }
   filechooser actionbar button:active, filechooser actionbar button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: #cc575d; }
   filechooser actionbar button:disabled {
@@ -4159,17 +4228,16 @@ filechooser actionbar button {
 filechooser actionbar entry {
   color: #BAC3CF;
   border-color: rgba(26, 28, 34, 0.4);
-  background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.4));
-  background-color: transparent; }
+  background-color: rgba(102, 109, 132, 0.4); }
   filechooser actionbar entry image, filechooser actionbar entry image:hover {
     color: inherit; }
   filechooser actionbar entry:focus {
     color: #ffffff;
     border-color: rgba(26, 28, 34, 0.4);
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
   filechooser actionbar entry:disabled {
     color: rgba(186, 195, 207, 0.55);
-    background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.25)); }
+    background-color: rgba(102, 109, 132, 0.25); }
 
 filechooser placessidebar.sidebar scrollbar,
 .nautilus-window placessidebar.sidebar scrollbar, .nemo-window .sidebar scrollbar, .caja-side-pane scrollbar {

--- a/common/gtk-3.0/3.20/gtk-solid.css
+++ b/common/gtk-3.0/3.20/gtk-solid.css
@@ -4,13 +4,11 @@
   -GtkTextView-error-underline-color: #FC4138;
   -GtkScrolledWindow-scrollbar-spacing: 0;
   -GtkToolItemGroup-expander-size: 11;
-  -GtkTreeView-expander-size: 11;
-  -GtkTreeView-horizontal-separator: 4;
   -GtkWidget-text-handle-width: 20;
   -GtkWidget-text-handle-height: 20;
   -GtkDialog-button-spacing: 4;
   -GtkDialog-action-area-border: 0;
-  outline-color: rgba(92, 97, 108, 0.3);
+  outline-color: alpha(currentColor,0.3);
   outline-style: dashed;
   outline-offset: -3px;
   outline-width: 1px;
@@ -107,7 +105,6 @@ popover.background.magnifier, .csd popover.background.osd, .csd popover.backgrou
   border: none;
   background-color: #353945;
   background-clip: padding-box;
-  outline-color: rgba(186, 195, 207, 0.3);
   box-shadow: none; }
 
 @keyframes spin {
@@ -133,8 +130,7 @@ entry {
   transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
   color: #5c616c;
   border-color: #cfd6e6;
-  background-color: #ffffff;
-  background-image: linear-gradient(to bottom, #ffffff); }
+  background-color: #ffffff; }
   entry.search {
     border-radius: 20px; }
   entry image {
@@ -155,51 +151,49 @@ entry {
     background-clip: border-box;
     color: #5c616c;
     border-color: #cc575d;
-    background-color: #ffffff;
-    background-image: linear-gradient(to bottom, #ffffff); }
+    background-color: #ffffff; }
   entry:disabled {
     color: rgba(92, 97, 108, 0.55);
     border-color: rgba(207, 214, 230, 0.55);
-    background-color: rgba(255, 255, 255, 0.55);
-    background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.55)); }
+    background-color: rgba(255, 255, 255, 0.55); }
   entry.warning {
-    color: #ffffff;
+    color: white;
     border-color: #F27835;
-    background-image: linear-gradient(to bottom, #f7ae86); }
+    background-color: #f7ae86; }
     entry.warning image {
-      color: #ffffff; }
+      color: white; }
     entry.warning:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #F27835);
+      color: white;
+      background-color: #F27835;
       box-shadow: none; }
     entry.warning selection, entry.warning selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #F27835; }
   entry.error {
-    color: #ffffff;
+    color: white;
     border-color: #FC4138;
-    background-image: linear-gradient(to bottom, #fd8d88); }
+    background-color: #fd8d88; }
     entry.error image {
-      color: #ffffff; }
+      color: white; }
     entry.error:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138);
+      color: white;
+      background-color: #FC4138;
       box-shadow: none; }
     entry.error selection, entry.error selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
   entry.search-missing {
-    color: #ffffff;
+    color: white;
     border-color: #FC4138;
-    background-image: linear-gradient(to bottom, #fd8d88); }
+    background-color: #fd8d88; }
     entry.search-missing image {
-      color: #ffffff; }
+      color: white; }
     entry.search-missing:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138);
+      color: white;
+      background-color: #FC4138;
       box-shadow: none; }
     entry.search-missing selection, entry.search-missing selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
   entry:drop(active):focus, entry:drop(active) {
     border-color: #F08437;
@@ -207,17 +201,16 @@ entry {
   .osd entry {
     color: #BAC3CF;
     border-color: rgba(26, 28, 34, 0.4);
-    background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.4));
-    background-color: transparent; }
+    background-color: rgba(102, 109, 132, 0.4); }
     .osd entry image, .osd entry image:hover {
       color: inherit; }
     .osd entry:focus {
       color: #ffffff;
       border-color: rgba(26, 28, 34, 0.4);
-      background-image: linear-gradient(to bottom, #cc575d); }
+      background-color: #cc575d; }
     .osd entry:disabled {
       color: rgba(186, 195, 207, 0.55);
-      background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.25)); }
+      background-color: rgba(102, 109, 132, 0.25); }
     .osd entry selection:focus, .osd entry selection {
       color: #cc575d;
       background-color: #ffffff; }
@@ -252,7 +245,6 @@ button {
   border-radius: 3px;
   padding: 2px 6px;
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: #fbfbfc; }
   button separator {
@@ -269,17 +261,18 @@ button {
         transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   button:hover {
     color: #5c616c;
-    outline-color: rgba(92, 97, 108, 0.3);
     border-color: #cfd6e6;
     background-color: white;
     -gtk-icon-effect: highlight; }
   button:active, button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d;
     background-clip: border-box;
     transition-duration: 50ms; }
+    button:active:not(:disabled) label:disabled, button:checked:not(:disabled) label:disabled {
+      color: inherit;
+      opacity: 0.6; }
   button:active {
     color: #5c616c; }
   button:active:hover, button:checked {
@@ -327,7 +320,6 @@ button {
     box-shadow: none; }
   button.osd {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     background-color: #353945;
     border-color: #23262e; }
     button.osd.image-button {
@@ -338,7 +330,6 @@ button {
       color: #cc575d; }
     button.osd:active, button.osd:checked {
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.4);
       background-color: #cc575d; }
     button.osd:disabled {
@@ -347,18 +338,15 @@ button {
       background-color: rgba(102, 109, 132, 0.25); }
   .osd button {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: rgba(102, 109, 132, 0.4); }
     .osd button:hover {
       color: #BAC3CF;
-      outline-color: rgba(186, 195, 207, 0.3);
       border-color: rgba(26, 28, 34, 0.4);
       background-color: rgba(119, 127, 151, 0.5); }
     .osd button:active, .osd button:checked {
       background-clip: padding-box;
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.4);
       background-color: #cc575d; }
     .osd button:disabled {
@@ -372,7 +360,6 @@ button {
       box-shadow: none; }
       .osd button.flat:hover, .osd button.sidebar-button:hover {
         color: #BAC3CF;
-        outline-color: rgba(186, 195, 207, 0.3);
         border-color: rgba(26, 28, 34, 0.4);
         background-color: rgba(119, 127, 151, 0.5); }
       .osd button.flat:disabled, .osd button.sidebar-button:disabled {
@@ -382,7 +369,6 @@ button {
         background-image: none; }
       .osd button.flat:active, .osd button.sidebar-button:active, .osd button.flat:checked, .osd button.sidebar-button:checked {
         color: #ffffff;
-        outline-color: rgba(255, 255, 255, 0.3);
         border-color: rgba(26, 28, 34, 0.4);
         background-color: #cc575d; }
   .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active):not(:only-child),
@@ -390,26 +376,22 @@ button {
     box-shadow: none; }
   button.suggested-action {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
-    background-color: #be3941;
-    border-color: #be3941; }
+    color: white;
+    background-color: #BE3941;
+    border-color: #BE3941; }
     button.suggested-action.flat, button.suggested-action.sidebar-button {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
-      color: #be3941;
-      outline-color: rgba(190, 57, 65, 0.3); }
+      color: #BE3941; }
     button.suggested-action:hover {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #ce5c63;
       border-color: #ce5c63; }
     button.suggested-action:active, button.suggested-action:checked {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #972d34;
       border-color: #972d34; }
     button.suggested-action.flat:disabled, button.suggested-action.sidebar-button:disabled {
@@ -424,26 +406,22 @@ button {
         color: rgba(92, 97, 108, 0.55); }
   button.destructive-action {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #F04A50;
     border-color: #F04A50; }
     button.destructive-action.flat, button.destructive-action.sidebar-button {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
-      color: #F04A50;
-      outline-color: rgba(240, 74, 80, 0.3); }
+      color: #F04A50; }
     button.destructive-action:hover {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #f4797e;
       border-color: #f4797e; }
     button.destructive-action:active, button.destructive-action:checked {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #ec1b22;
       border-color: #ec1b22; }
     button.destructive-action.flat:disabled, button.destructive-action.sidebar-button:disabled {
@@ -483,23 +461,22 @@ button {
     background-position: right 3px, right 4px; }
     .stack-switcher > button.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > image:dir(rtl), button stacksidebar row.needs-attention > label:dir(rtl), stacksidebar button row.needs-attention > label:dir(rtl) {
       background-position: left 3px, left 4px; }
+  button.font separator, button.file separator {
+    background-color: transparent; }
   .inline-toolbar button, .inline-toolbar button:backdrop {
     border-radius: 2px;
     border-width: 1px; }
 
 .inline-toolbar toolbutton > button {
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: #fbfbfc; }
   .inline-toolbar toolbutton > button:hover {
     color: #5c616c;
-    outline-color: rgba(92, 97, 108, 0.3);
     border-color: #cfd6e6;
     background-color: white; }
   .inline-toolbar toolbutton > button:active, .inline-toolbar toolbutton > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d; }
   .inline-toolbar toolbutton > button:disabled {
@@ -576,12 +553,23 @@ button {
 .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
   box-shadow: inset 1px 0 #cfd6e6; }
 
-.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
+  box-shadow: inset 1px 0 rgba(207, 214, 230, 0.5); }
+
 .linked:not(.vertical):not(.path-bar) > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
-.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child) {
+.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:disabled,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked:not(.vertical):not(.path-bar) > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child) {
   box-shadow: none; }
 
 .linked:not(.vertical).path-bar > button + button {
@@ -658,12 +646,23 @@ button {
 .linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
   box-shadow: inset 0 1px #cfd6e6; }
 
-.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
+  box-shadow: inset 0 1px rgba(207, 214, 230, 0.5); }
+
 .linked.vertical > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
-.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child) {
+.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:disabled,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked.vertical > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child) {
   box-shadow: none; }
 
 toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat, toolbar.inline-toolbar toolbutton > button.sidebar-button, .inline-toolbar toolbutton > button.sidebar-button, .linked:not(.vertical) > entry,
@@ -709,7 +708,7 @@ toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > bu
   border-style: solid; }
 
 menuitem.button.flat,
-modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover, .app-notification button.flat, .app-notification button.sidebar-button, .app-notification button.flat:disabled, .app-notification button.sidebar-button:disabled {
+modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover, .app-notification button.flat, .app-notification button.sidebar-button, .app-notification button.flat:disabled, .app-notification button.sidebar-button:disabled, calendar.button {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
@@ -760,16 +759,7 @@ modelbutton.flat arrow.right {
     color: #b8383e; }
     *:selected *:link:active, *:selected button:active:link, *:selected button:active:visited {
       color: #f5dddf; }
-  .info *:link, .info button:link, .info button:visited,
-  .question *:link,
-  .question button:link,
-  .question button:visited,
-  .warning *:link,
-  .warning button:link,
-  .warning button:visited,
-  .error *:link,
-  .error button:link,
-  .error button:visited, *:link:selected, button:selected:link, button:selected:visited, headerbar.selection-mode .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link,
+  infobar.info *:link, infobar.info button:link, infobar.info button:visited, infobar.question *:link, infobar.question button:link, infobar.question button:visited, infobar.warning *:link, infobar.warning button:link, infobar.warning button:visited, infobar.error *:link, infobar.error button:link, infobar.error button:visited, *:link:selected, button:selected:link, button:selected:visited, headerbar.selection-mode .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link,
   *:selected *:link,
   *:selected button:link,
   *:selected button:visited {
@@ -800,6 +790,10 @@ spinbutton:not(.vertical) > button + button {
 spinbutton:not(.vertical) > button:hover:not(:active),
 spinbutton:not(.vertical) > button:hover + button {
   box-shadow: inset 1px 0 #cfd6e6; }
+
+spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover),
+spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled {
+  box-shadow: inset 1px 0 rgba(207, 214, 230, 0.5); }
 
 spinbutton:not(.vertical) > button:first-child:hover:not(:active),
 spinbutton:not(.vertical) > button.up:dir(rtl):hover:not(:active),
@@ -886,7 +880,7 @@ toolbar, .inline-toolbar {
   toolbar:not(.inline-toolbar) .linked > entry, .inline-toolbar:not(.inline-toolbar) .linked > entry {
     margin-right: 0; }
 
-.primary-toolbar {
+.primary-toolbar:not(.libreoffice-toolbar) {
   color: rgba(82, 93, 118, 0.8);
   background-color: #e7e8eb;
   box-shadow: none;
@@ -1032,22 +1026,21 @@ window.csd > .titlebar:not(headerbar):backdrop {
   box-shadow: none; }
 
 .titlebar:not(headerbar) > separator {
-  background-image: linear-gradient(to top, #d4d5db); }
+  background-image: linear-gradient(to bottom, #d4d5db, #d4d5db); }
 
-.primary-toolbar separator, headerbar separator.titlebutton, .titlebar:not(headerbar) separator.titlebutton {
+.primary-toolbar:not(.libreoffice-toolbar) separator, headerbar separator.titlebutton, .titlebar:not(headerbar) separator.titlebutton {
   min-width: 1px;
   min-height: 1px;
   background: none;
   border-width: 0 1px;
   border-image: linear-gradient(to bottom, rgba(82, 93, 118, 0) 25%, rgba(82, 93, 118, 0.15) 25%, rgba(82, 93, 118, 0.15) 75%, rgba(82, 93, 118, 0) 75%) 0 1/0 1px stretch; }
-  .primary-toolbar separator:backdrop, headerbar separator.titlebutton:backdrop, .titlebar:not(headerbar) separator.titlebutton:backdrop {
+  .primary-toolbar:not(.libreoffice-toolbar) separator:backdrop, headerbar separator.titlebutton:backdrop, .titlebar:not(headerbar) separator.titlebutton:backdrop {
     opacity: 0.6; }
 
 .primary-toolbar entry, headerbar entry {
   color: rgba(82, 93, 118, 0.8);
   border-color: rgba(82, 93, 118, 0.1);
-  background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.9));
-  background-color: transparent; }
+  background-color: rgba(255, 255, 255, 0.9); }
   .primary-toolbar entry image, headerbar entry image, .primary-toolbar entry image:hover, headerbar entry image:hover {
     color: inherit; }
   .primary-toolbar entry:backdrop, headerbar entry:backdrop {
@@ -1055,13 +1048,14 @@ window.csd > .titlebar:not(headerbar):backdrop {
   .primary-toolbar entry:focus, headerbar entry:focus {
     color: #ffffff;
     border-color: #cc575d;
-    background-image: linear-gradient(to bottom, #cc575d);
+    background-color: #cc575d;
     background-clip: border-box; }
     .primary-toolbar entry:focus image, headerbar entry:focus image {
       color: #ffffff; }
   .primary-toolbar entry:disabled, headerbar entry:disabled {
     color: rgba(82, 93, 118, 0.35);
-    background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.75)); }
+    border-color: rgba(82, 93, 118, 0.1);
+    background-color: rgba(255, 255, 255, 0.75); }
   .primary-toolbar entry selection:focus, headerbar entry selection:focus {
     background-color: #ffffff;
     color: #cc575d; }
@@ -1070,29 +1064,28 @@ window.csd > .titlebar:not(headerbar):backdrop {
     background-image: none;
     background-color: transparent; }
   .primary-toolbar entry.warning, headerbar entry.warning {
-    color: #ffffff;
+    color: white;
     border-color: #F27835;
-    background-image: linear-gradient(to bottom, #eea57e); }
+    background-color: #eea57e; }
     .primary-toolbar entry.warning:focus, headerbar entry.warning:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #F27835); }
+      color: white;
+      background-color: #F27835; }
     .primary-toolbar entry.warning selection, headerbar entry.warning selection, .primary-toolbar entry.warning selection:focus, headerbar entry.warning selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #F27835; }
   .primary-toolbar entry.error, headerbar entry.error {
-    color: #ffffff;
+    color: white;
     border-color: #FC4138;
-    background-image: linear-gradient(to bottom, #f48480); }
+    background-color: #f48480; }
     .primary-toolbar entry.error:focus, headerbar entry.error:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138); }
+      color: white;
+      background-color: #FC4138; }
     .primary-toolbar entry.error selection, headerbar entry.error selection, .primary-toolbar entry.error selection:focus, headerbar entry.error selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
 
 .primary-toolbar button, headerbar button {
   color: rgba(82, 93, 118, 0.8);
-  outline-color: rgba(82, 93, 118, 0.1);
   outline-offset: -3px;
   background-color: rgba(231, 232, 235, 0);
   border-color: rgba(231, 232, 235, 0); }
@@ -1100,12 +1093,10 @@ window.csd > .titlebar:not(headerbar):backdrop {
     opacity: 0.7; }
   .primary-toolbar button:hover, headerbar button:hover {
     color: rgba(82, 93, 118, 0.8);
-    outline-color: rgba(82, 93, 118, 0.1);
     border-color: rgba(82, 93, 118, 0.1);
     background-color: rgba(251, 251, 252, 0.9); }
   .primary-toolbar button:active, headerbar button:active, .primary-toolbar button:checked, headerbar button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d;
     background-clip: border-box; }
@@ -1133,19 +1124,17 @@ window.csd > .titlebar:not(headerbar):backdrop {
   border-radius: 3px;
   border-style: solid; }
 
-.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
   box-shadow: none; }
 
 .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .linked:not(.vertical).path-bar > button, headerbar .linked:not(.vertical).path-bar > button {
   color: rgba(82, 93, 118, 0.8);
-  outline-color: rgba(82, 93, 118, 0.1);
   border-color: rgba(82, 93, 118, 0.1);
   background-color: rgba(251, 251, 252, 0.9); }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar .linked:not(.vertical).path-bar > button:hover, headerbar .linked:not(.vertical).path-bar > button:hover {
     background-color: rgba(255, 255, 255, 0.9); }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar .linked:not(.vertical).path-bar > button:active, headerbar .linked:not(.vertical).path-bar > button:active, .primary-toolbar .linked:not(.vertical).path-bar > button:checked, headerbar .linked:not(.vertical).path-bar > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d; }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, .primary-toolbar .linked:not(.vertical).path-bar > button:disabled, headerbar .linked:not(.vertical).path-bar > button:disabled {
@@ -1204,26 +1193,22 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar button.suggested-action, headerbar button.suggested-action {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
-  background-color: #be3941;
-  border-color: #be3941; }
+  color: white;
+  background-color: #BE3941;
+  border-color: #BE3941; }
   .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat, .primary-toolbar button.suggested-action.sidebar-button, headerbar button.suggested-action.sidebar-button {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
-    color: #be3941;
-    outline-color: rgba(190, 57, 65, 0.3); }
+    color: #BE3941; }
   .primary-toolbar button.suggested-action:hover, headerbar button.suggested-action:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #ce5c63;
     border-color: #ce5c63; }
   .primary-toolbar button.suggested-action:active, headerbar button.suggested-action:active, .primary-toolbar button.suggested-action:checked, headerbar button.suggested-action:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #972d34;
     border-color: #972d34; }
   .primary-toolbar button.suggested-action.flat:disabled, headerbar button.suggested-action.flat:disabled, .primary-toolbar button.suggested-action.sidebar-button:disabled, headerbar button.suggested-action.sidebar-button:disabled, .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
@@ -1237,26 +1222,22 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar button.destructive-action, headerbar button.destructive-action {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
+  color: white;
   background-color: #F04A50;
   border-color: #F04A50; }
   .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat, .primary-toolbar button.destructive-action.sidebar-button, headerbar button.destructive-action.sidebar-button {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
-    color: #F04A50;
-    outline-color: rgba(240, 74, 80, 0.3); }
+    color: #F04A50; }
   .primary-toolbar button.destructive-action:hover, headerbar button.destructive-action:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #f4797e;
     border-color: #f4797e; }
   .primary-toolbar button.destructive-action:active, headerbar button.destructive-action:active, .primary-toolbar button.destructive-action:checked, headerbar button.destructive-action:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #ec1b22;
     border-color: #ec1b22; }
   .primary-toolbar button.destructive-action.flat:disabled, headerbar button.destructive-action.flat:disabled, .primary-toolbar button.destructive-action.sidebar-button:disabled, headerbar button.destructive-action.sidebar-button:disabled, .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
@@ -1274,7 +1255,6 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar spinbutton:not(.vertical) button, headerbar spinbutton:not(.vertical) button, .primary-toolbar spinbutton:not(.vertical) button:disabled, headerbar spinbutton:not(.vertical) button:disabled {
   color: rgba(82, 93, 118, 0.8);
-  outline-color: rgba(82, 93, 118, 0.1);
   border-color: rgba(82, 93, 118, 0.1);
   background-color: rgba(251, 251, 252, 0.9); }
 
@@ -1283,7 +1263,6 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar spinbutton:not(.vertical) button:active, headerbar spinbutton:not(.vertical) button:active, .primary-toolbar spinbutton:not(.vertical) button:checked, headerbar spinbutton:not(.vertical) button:checked {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   border-color: #cc575d;
   background-color: #cc575d; }
 
@@ -1294,6 +1273,9 @@ window.csd > .titlebar:not(headerbar):backdrop {
   border-left-style: none; }
 
 .primary-toolbar spinbutton:not(.vertical) > button:hover:not(:active), headerbar spinbutton:not(.vertical) > button:hover:not(:active), .primary-toolbar spinbutton:not(.vertical) > button:hover + button, headerbar spinbutton:not(.vertical) > button:hover + button {
+  box-shadow: inset 1px 0 rgba(82, 93, 118, 0.1); }
+
+.primary-toolbar spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover), headerbar spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover), .primary-toolbar spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled, headerbar spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled {
   box-shadow: inset 1px 0 rgba(82, 93, 118, 0.1); }
 
 .primary-toolbar spinbutton:not(.vertical) > button:first-child:hover:not(:active), headerbar spinbutton:not(.vertical) > button:first-child:hover:not(:active), .primary-toolbar spinbutton:not(.vertical) > entry + button:not(:active):hover, headerbar spinbutton:not(.vertical) > entry + button:not(:active):hover {
@@ -1308,18 +1290,18 @@ window.csd > .titlebar:not(headerbar):backdrop {
 .primary-toolbar combobox > .linked > button.combo, headerbar combobox > .linked > button.combo {
   color: rgba(82, 93, 118, 0.8);
   border-color: rgba(82, 93, 118, 0.1);
-  background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.9));
-  background-color: transparent; }
+  background-color: rgba(255, 255, 255, 0.9); }
   .primary-toolbar combobox > .linked > button.combo image, headerbar combobox > .linked > button.combo image, .primary-toolbar combobox > .linked > button.combo image:hover, headerbar combobox > .linked > button.combo image:hover {
     color: inherit; }
   .primary-toolbar combobox > .linked > button.combo:hover, headerbar combobox > .linked > button.combo:hover {
     color: #ffffff;
     border-color: #cc575d;
-    background-image: linear-gradient(to bottom, #cc575d);
+    background-color: #cc575d;
     box-shadow: none; }
   .primary-toolbar combobox > .linked > button.combo:disabled, headerbar combobox > .linked > button.combo:disabled {
     color: rgba(82, 93, 118, 0.35);
-    background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.75)); }
+    border-color: rgba(82, 93, 118, 0.1);
+    background-color: rgba(255, 255, 255, 0.75); }
 
 .primary-toolbar combobox > .linked > entry.combo:dir(ltr), headerbar combobox > .linked > entry.combo:dir(ltr) {
   border-right-style: none; }
@@ -1396,13 +1378,15 @@ window.csd > .titlebar:not(headerbar):backdrop {
   padding-right: 4px; }
 
 treeview.view {
-  -GtkTreeView-grid-line-width: 1;
-  -GtkTreeView-grid-line-pattern: '';
-  -GtkTreeView-tree-line-width: 1;
-  -GtkTreeView-tree-line-pattern: '';
-  -GtkTreeView-expander-size: 16;
   border-left-color: rgba(92, 97, 108, 0.15);
   border-top-color: rgba(0, 0, 0, 0.1); }
+  * {
+    -GtkTreeView-horizontal-separator: 4;
+    -GtkTreeView-grid-line-width: 1;
+    -GtkTreeView-grid-line-pattern: '';
+    -GtkTreeView-tree-line-width: 1;
+    -GtkTreeView-tree-line-pattern: '';
+    -GtkTreeView-expander-size: 16; }
   treeview.view acceleditor > label {
     background-color: #cc575d; }
   treeview.view:selected, treeview.view:selected:focus {
@@ -1440,16 +1424,21 @@ treeview.view {
   treeview.view.progressbar, treeview.view.progressbar:focus {
     color: #ffffff;
     border-radius: 3px;
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
     treeview.view.progressbar:selected, treeview.view.progressbar:selected:focus, treeview.view.progressbar:focus:selected, treeview.view.progressbar:focus:selected:focus {
       color: #cc575d;
       box-shadow: none;
-      background-image: linear-gradient(to bottom, #ffffff); }
-  treeview.view.trough, treeview.view.trough:selected, treeview.view.trough:selected:focus {
+      background-color: #ffffff; }
+  treeview.view.trough {
     color: #5c616c;
-    background-image: linear-gradient(to bottom, #cfd6e6);
+    background-color: #cfd6e6;
     border-radius: 3px;
     border-width: 0; }
+    treeview.view.trough:selected, treeview.view.trough:selected:focus {
+      color: #ffffff;
+      background-color: rgba(0, 0, 0, 0.2);
+      border-radius: 3px;
+      border-width: 0; }
   treeview.view header button {
     min-height: 0;
     min-width: 0;
@@ -1839,7 +1828,7 @@ scrollbar {
     min-height: 40px; }
 
 switch {
-  font: 1;
+  font-size: 1px;
   min-width: 52px;
   min-height: 24px;
   background-size: 52px 24px;
@@ -2340,9 +2329,11 @@ frame > border,
   padding: 0;
   border-radius: 0;
   border: 1px solid #dcdfe3; }
-  frame > border.flat,
-  .frame.flat {
-    border-style: none; }
+
+frame.flat > border,
+frame > border.flat,
+.frame.flat {
+  border-style: none; }
 
 scrolledwindow viewport.frame {
   border-style: none; }
@@ -2474,19 +2465,16 @@ row.activatable:selected.has-open-popup, row.activatable:selected:hover {
     border: none; }
   .app-notification button {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: rgba(102, 109, 132, 0.4); }
     .app-notification button.flat, .app-notification button.sidebar-button {
       border-color: rgba(204, 87, 93, 0); }
     .app-notification button:hover {
       color: #BAC3CF;
-      outline-color: rgba(186, 195, 207, 0.3);
       border-color: rgba(26, 28, 34, 0.4);
       background-color: rgba(119, 127, 151, 0.5); }
     .app-notification button:active, .app-notification button:checked {
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.4);
       background-color: #cc575d;
       background-clip: padding-box; }
@@ -2512,24 +2500,16 @@ calendar {
   border-radius: 3px;
   padding: 2px; }
   calendar:selected {
-    background-color: #cc575d;
-    color: #ffffff;
     border-radius: 1.5px; }
   calendar.header {
     color: #5c616c;
-    border: none;
-    border-radius: 0; }
-  calendar.button, calendar.button:focus {
-    color: rgba(92, 97, 108, 0.45);
-    border-color: transparent;
-    background-color: transparent;
-    background-image: none; }
-    calendar.button:hover, calendar.button:focus:hover {
+    border: none; }
+  calendar.button {
+    color: rgba(92, 97, 108, 0.45); }
+    calendar.button:hover {
       color: #5c616c; }
-    calendar.button:disabled, calendar.button:focus:disabled {
-      color: rgba(92, 97, 108, 0.55);
-      background-color: transparent;
-      background-image: none; }
+    calendar.button:disabled {
+      color: rgba(92, 97, 108, 0.55); }
   calendar:indeterminate {
     color: alpha(currentColor,0.55); }
   calendar.highlight {
@@ -2630,7 +2610,7 @@ placessidebar row {
   placessidebar row.sidebar-placeholder-row {
     padding: 0 8px;
     min-height: 2px;
-    background-image: linear-gradient(to top, #F08437);
+    background-image: linear-gradient(to bottom, #F08437, #F08437);
     background-clip: content-box; }
   placessidebar row.sidebar-new-bookmark-row {
     color: #cc575d; }
@@ -2660,15 +2640,15 @@ paned > separator {
   -gtk-icon-source: none;
   border-style: none;
   background-color: transparent;
-  background-image: linear-gradient(to top, #dcdfe3);
+  background-image: linear-gradient(to bottom, #dcdfe3, #dcdfe3);
   background-size: 1px 1px; }
   paned > separator:selected {
-    background-image: linear-gradient(to top, #cc575d); }
+    background-image: linear-gradient(to bottom, #cc575d, #cc575d); }
   paned > separator.wide {
     min-width: 5px;
     min-height: 5px;
     background-color: #F5F6F7;
-    background-image: linear-gradient(to top, #dcdfe3), linear-gradient(to top, #dcdfe3);
+    background-image: linear-gradient(to bottom, #dcdfe3, #dcdfe3), linear-gradient(to bottom, #dcdfe3, #dcdfe3);
     background-size: 1px 1px, 1px 1px; }
 
 paned.horizontal > separator {
@@ -2700,107 +2680,44 @@ paned.vertical > separator {
 
 infobar {
   border-style: none; }
+  infobar.info, infobar.question, infobar.warning, infobar.error {
+    background-color: #cc575d;
+    color: #ffffff;
+    caret-color: currentColor; }
+    infobar.info selection, infobar.question selection, infobar.warning selection, infobar.error selection {
+      color: #cc575d;
+      background-color: #ffffff; }
 
-.info,
-.question,
-.warning,
-.error {
-  background-color: #cc575d;
-  color: #ffffff; }
-  .info label:selected:focus, .info label:selected:hover, .info label:selected,
-  .question label:selected:focus,
-  .question label:selected:hover,
-  .question label:selected,
-  .warning label:selected:focus,
-  .warning label:selected:hover,
-  .warning label:selected,
-  .error label:selected:focus,
-  .error label:selected:hover,
-  .error label:selected {
-    color: #cc575d;
-    background-color: #ffffff; }
-
-.selection-mode.primary-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, .info button,
-.question button,
-.warning button,
-.error button, .nautilus-window .floating-bar button {
+.selection-mode.primary-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, infobar.info button, infobar.question button, infobar.warning button, infobar.error button, .nautilus-window .floating-bar button {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.5); }
 
-row:selected button.flat, row:selected button.sidebar-button, .info button.flat, .info button.sidebar-button,
-.question button.flat,
-.question button.sidebar-button,
-.warning button.flat,
-.warning button.sidebar-button,
-.error button.flat,
-.error button.sidebar-button, .nautilus-window .floating-bar button.flat, .nautilus-window .floating-bar button.sidebar-button {
+row:selected button.flat, row:selected button.sidebar-button, infobar.info button.flat, infobar.info button.sidebar-button, infobar.question button.flat, infobar.question button.sidebar-button, infobar.warning button.flat, infobar.warning button.sidebar-button, infobar.error button.flat, infobar.error button.sidebar-button, .nautilus-window .floating-bar button.flat, .nautilus-window .floating-bar button.sidebar-button {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0); }
-  .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, row:selected button.flat:disabled, row:selected button.sidebar-button:disabled, .info button.flat:disabled, .info button.sidebar-button:disabled,
-  .question button.flat:disabled,
-  .question button.sidebar-button:disabled,
-  .warning button.flat:disabled,
-  .warning button.sidebar-button:disabled,
-  .error button.flat:disabled,
-  .error button.sidebar-button:disabled, .nautilus-window .floating-bar button.flat:disabled, .nautilus-window .floating-bar button.sidebar-button:disabled, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled label, row:selected button.sidebar-button:disabled label, .info button.flat:disabled label, .info button.sidebar-button:disabled label,
-  .question button.flat:disabled label,
-  .question button.sidebar-button:disabled label,
-  .warning button.flat:disabled label,
-  .warning button.sidebar-button:disabled label,
-  .error button.flat:disabled label,
-  .error button.sidebar-button:disabled label, .nautilus-window .floating-bar button.flat:disabled label, .nautilus-window .floating-bar button.sidebar-button:disabled label {
+  .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, row:selected button.flat:disabled, row:selected button.sidebar-button:disabled, infobar.info button.flat:disabled, infobar.info button.sidebar-button:disabled, infobar.question button.flat:disabled, infobar.question button.sidebar-button:disabled, infobar.warning button.flat:disabled, infobar.warning button.sidebar-button:disabled, infobar.error button.flat:disabled, infobar.error button.sidebar-button:disabled, .nautilus-window .floating-bar button.flat:disabled, .nautilus-window .floating-bar button.sidebar-button:disabled, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled label, row:selected button.sidebar-button:disabled label, infobar.info button.flat:disabled label, infobar.info button.sidebar-button:disabled label, infobar.question button.flat:disabled label, infobar.question button.sidebar-button:disabled label, infobar.warning button.flat:disabled label, infobar.warning button.sidebar-button:disabled label, infobar.error button.flat:disabled label, infobar.error button.sidebar-button:disabled label, .nautilus-window .floating-bar button.flat:disabled label, .nautilus-window .floating-bar button.sidebar-button:disabled label {
     color: rgba(255, 255, 255, 0.4); }
 
-row:selected button:hover, .info button:hover,
-.question button:hover,
-.warning button:hover,
-.error button:hover, .nautilus-window .floating-bar button:hover {
+row:selected button:hover, infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover, .nautilus-window .floating-bar button:hover {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   background-color: rgba(255, 255, 255, 0.2);
   border-color: rgba(255, 255, 255, 0.8); }
 
-.selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, .info button:active,
-.question button:active,
-.warning button:active,
-.error button:active, .nautilus-window .floating-bar button:active, .selection-mode.primary-toolbar button:hover:active, headerbar.selection-mode button:hover:active, .selection-mode.primary-toolbar button:hover:checked, headerbar.selection-mode button:hover:checked, row:selected button:active:hover, .info button:active:hover,
-.question button:active:hover,
-.warning button:active:hover,
-.error button:active:hover, .nautilus-window .floating-bar button:active:hover, row:selected button:checked, .info button:checked,
-.question button:checked,
-.warning button:checked,
-.error button:checked, .nautilus-window .floating-bar button:checked {
+.selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, .nautilus-window .floating-bar button:active, .selection-mode.primary-toolbar button:hover:active, headerbar.selection-mode button:hover:active, .selection-mode.primary-toolbar button:hover:checked, headerbar.selection-mode button:hover:checked, row:selected button:active:hover, infobar.info button:active:hover, infobar.question button:active:hover, infobar.warning button:active:hover, infobar.error button:active:hover, .nautilus-window .floating-bar button:active:hover, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked, .nautilus-window .floating-bar button:checked {
   color: #cc575d;
-  outline-color: rgba(204, 87, 93, 0.3);
   background-color: #ffffff;
   border-color: #ffffff; }
 
-row:selected button:disabled, .info button:disabled,
-.question button:disabled,
-.warning button:disabled,
-.error button:disabled, .nautilus-window .floating-bar button:disabled {
+row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, .nautilus-window .floating-bar button:disabled {
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.4); }
-  row:selected button:disabled, .info button:disabled,
-  .question button:disabled,
-  .warning button:disabled,
-  .error button:disabled, .nautilus-window .floating-bar button:disabled, row:selected button:disabled label, .info button:disabled label,
-  .question button:disabled label,
-  .warning button:disabled label,
-  .error button:disabled label, .nautilus-window .floating-bar button:disabled label {
+  row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, .nautilus-window .floating-bar button:disabled, row:selected button:disabled label, infobar.info button:disabled label, infobar.question button:disabled label, infobar.warning button:disabled label, infobar.error button:disabled label, .nautilus-window .floating-bar button:disabled label {
     color: rgba(255, 255, 255, 0.5); }
-  .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, row:selected button:disabled:active, .info button:disabled:active,
-  .question button:disabled:active,
-  .warning button:disabled:active,
-  .error button:disabled:active, .nautilus-window .floating-bar button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:checked, .info button:disabled:checked,
-  .question button:disabled:checked,
-  .warning button:disabled:checked,
-  .error button:disabled:checked, .nautilus-window .floating-bar button:disabled:checked {
+  .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, .nautilus-window .floating-bar button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked, .nautilus-window .floating-bar button:disabled:checked {
     color: #cc575d;
     background-color: rgba(255, 255, 255, 0.5);
     border-color: rgba(255, 255, 255, 0.4); }
@@ -2875,12 +2792,10 @@ colorswatch#add-color-button {
   border-style: solid;
   border-width: 1px;
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: #fbfbfc; }
   colorswatch#add-color-button:hover {
     color: #5c616c;
-    outline-color: rgba(92, 97, 108, 0.3);
     border-color: #cfd6e6;
     background-color: white; }
   colorswatch#add-color-button overlay {
@@ -2904,7 +2819,6 @@ colorchooser .popover.osd {
 
 .scale-popup button:hover {
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: white; }
 
@@ -2913,13 +2827,14 @@ popover.background.touch-selection, .csd popover.background.touch-selection {
   font: initial; }
 
 .monospace {
-  font: Monospace; }
+  font-family: Monospace; }
 
 button.circular, button.nautilus-circular-button.image-button,
 button.circular-button {
   padding: 0;
-  min-width: 26px;
-  min-height: 26px;
+  min-width: 16px;
+  min-height: 24px;
+  padding: 2px 6px;
   border-radius: 50%;
   -gtk-outline-radius: 50%; }
   button.circular label, button.nautilus-circular-button.image-button label,
@@ -2997,14 +2912,12 @@ headerbar button.titlebutton,
   headerbar button.titlebutton:hover,
   .titlebar button.titlebutton:hover {
     color: rgba(82, 93, 118, 0.8);
-    outline-color: rgba(82, 93, 118, 0.1);
     border-color: rgba(82, 93, 118, 0.1);
     background-color: rgba(251, 251, 252, 0.9); }
   headerbar button.titlebutton:active, headerbar button.titlebutton:checked,
   .titlebar button.titlebutton:active,
   .titlebar button.titlebutton:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d; }
   headerbar button.titlebutton.close, headerbar button.titlebutton.maximize, headerbar button.titlebutton.minimize,
@@ -3066,7 +2979,7 @@ textview text selection, flowbox flowboxchild:selected, entry selection:focus, e
 modelbutton.flat:active,
 modelbutton.flat:active arrow,
 modelbutton.flat:selected,
-modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
+modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, calendar:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
 .nautilus-window placessidebar.sidebar row.sidebar-row.has-open-popup:selected,
 .nautilus-window placessidebar.sidebar row.sidebar-row:selected,
 .nautilus-window placessidebar.sidebar row.sidebar-row:selected:hover,
@@ -3080,20 +2993,19 @@ modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:
   modelbutton.flat:active,
   modelbutton.flat:active arrow,
   modelbutton.flat:selected,
-  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
+  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, calendar:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
   .nautilus-window placessidebar.sidebar row.sidebar-row.has-open-popup:selected,
   .nautilus-window placessidebar.sidebar row.sidebar-row:selected,
   .nautilus-window placessidebar.sidebar row.sidebar-row:selected:hover,
   .nautilus-window placessidebar.sidebar row.sidebar-row:active:hover {
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3); }
+    color: #ffffff; }
     row:selected label:disabled, label:disabled:selected, .view:disabled:selected, iconview:disabled:selected, iconview:disabled:selected:focus, .view text:disabled:selected, iconview text:disabled:selected,
     textview text:disabled:selected, iconview text selection:disabled:focus, .view text selection:disabled, iconview text selection:disabled,
     textview text selection:disabled, flowbox flowboxchild:disabled:selected, label:disabled selection, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
     modelbutton.flat:disabled:active,
     modelbutton.flat:active arrow:disabled,
     modelbutton.flat:disabled:selected,
-    modelbutton.flat:selected arrow:disabled, treeview.view:disabled:selected:focus, row:disabled:selected, .nemo-window .nemo-window-pane widget.entry:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:active:hover,
+    modelbutton.flat:selected arrow:disabled, treeview.view:disabled:selected:focus, row:disabled:selected, calendar:disabled:selected, .nemo-window .nemo-window-pane widget.entry:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:active:hover,
     .nautilus-window placessidebar.sidebar row.sidebar-row:disabled:selected,
     .nautilus-window placessidebar.sidebar row.sidebar-row:disabled:active:hover {
       color: #e6abae; }
@@ -3102,10 +3014,12 @@ modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:
 terminal-window notebook > header.top > tabs > tab:checked {
   box-shadow: inset 0 -1px #dcdfe3; }
 
-terminal-window notebook > header.top {
+terminal-window notebook > header.top,
+.mate-terminal notebook > header.top {
   padding-top: 3px;
   box-shadow: inset 0 1px #d4d5db, inset 0 -1px #dcdfe3; }
-  terminal-window notebook > header.top button {
+  terminal-window notebook > header.top button,
+  .mate-terminal notebook > header.top button {
     padding: 0;
     min-width: 24px;
     min-height: 24px; }
@@ -3114,7 +3028,7 @@ terminal-window notebook > header.top {
   border-radius: 2px; }
 
 .nautilus-desktop.nautilus-canvas-item, .nemo-desktop.nemo-canvas-item, .caja-desktop {
-  color: #ffffff;
+  color: white;
   text-shadow: 1px 1px rgba(0, 0, 0, 0.6); }
   .nautilus-desktop.nautilus-canvas-item:active, .nemo-desktop.nemo-canvas-item:active, .caja-desktop:active {
     color: #5c616c; }
@@ -3157,12 +3071,10 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
 @keyframes needs_attention_keyframes {
   0% {
     color: rgba(82, 93, 118, 0.8);
-    outline-color: rgba(82, 93, 118, 0.1);
     border-color: rgba(82, 93, 118, 0.1);
     background-color: rgba(251, 251, 252, 0.9); }
   100% {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d; } }
 
@@ -3172,6 +3084,17 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
 .nautilus-operations-button-needs-attention-multiple {
   animation: needs_attention_keyframes 3s ease-in-out;
   animation-iteration-count: 3; }
+
+.conflict-row.activatable, .conflict-row.activatable:active {
+  color: white;
+  background-color: #FC4138; }
+
+.conflict-row.activatable:hover {
+  background-color: #fd716a; }
+
+.conflict-row.activatable:selected {
+  color: #ffffff;
+  background-color: #cc575d; }
 
 .nemo-window .nemo-places-sidebar.frame {
   border-width: 0; }
@@ -3184,12 +3107,10 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
   border-radius: 3px;
   color: #5c616c;
   border-color: #cc575d;
-  background-color: #ffffff;
-  background-image: linear-gradient(to bottom, #ffffff); }
+  background-color: #ffffff; }
 
 .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button {
   color: rgba(82, 93, 118, 0.8);
-  outline-color: rgba(82, 93, 118, 0.1);
   border-color: rgba(82, 93, 118, 0.1);
   background-color: rgba(251, 251, 252, 0.9); }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:not(:last-child):not(:only-child) {
@@ -3198,7 +3119,6 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
     background-color: rgba(255, 255, 255, 0.9); }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:active, .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d; }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:disabled {
@@ -3292,6 +3212,27 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
   margin: 2px;
   padding: 2px; }
 
+.gedit-map-frame border {
+  border-color: rgba(0, 0, 0, 0.3);
+  border-width: 0; }
+  .gedit-map-frame border:dir(ltr) {
+    border-left-width: 1px; }
+  .gedit-map-frame border:dir(rtl) {
+    border-right-width: 1px; }
+
+.pluma-window statusbar frame > border {
+  border: none; }
+
+.pluma-window notebook > stack scrolledwindow {
+  border-width: 0 0 1px 0; }
+
+#pluma-status-combo-button {
+  min-height: 0;
+  padding: 0;
+  border-top: none;
+  border-bottom: none;
+  border-radius: 0; }
+
 .gb-search-entry-occurrences-tag {
   background: none; }
 
@@ -3320,6 +3261,8 @@ pillbox {
   color: #ffffff;
   background-color: #cc575d;
   border-radius: 3px; }
+  pillbox:disabled label {
+    color: rgba(255, 255, 255, 0.5); }
 
 docktabstrip {
   padding: 0 6px;
@@ -3352,6 +3295,62 @@ dockoverlayedge {
   dockoverlayedge.left-edge tab:checked,
   dockoverlayedge.right-edge tab:checked {
     border-width: 1px 0; }
+
+popover.messagepopover.background {
+  padding: 0; }
+
+popover.messagepopover .popover-content-area {
+  margin: 16px; }
+
+popover.messagepopover .popover-action-area {
+  margin: 8px; }
+  popover.messagepopover .popover-action-area button:not(:first-child):not(:last-child) {
+    margin: 0 4px; }
+
+popover.popover-selector {
+  padding: 0; }
+  popover.popover-selector list row {
+    padding: 5px 0; }
+  popover.popover-selector list row image {
+    margin-left: 3px;
+    margin-right: 10px; }
+
+entry.search.preferences-search {
+  border: none;
+  border-right: 1px solid #dcdfe3;
+  border-bottom: 1px solid #dcdfe3;
+  border-radius: 0; }
+
+preferences stacksidebar.sidebar list {
+  background-image: linear-gradient(to bottom, #ffffff, #ffffff); }
+
+preferences stacksidebar.sidebar list separator {
+  background-color: transparent; }
+
+devhelppanel entry:focus,
+symboltreepanel entry:focus {
+  border-color: #dcdfe3; }
+
+button.run-arrow-button {
+  min-width: 12px; }
+
+omnibar.linked > entry:not(:only-child) {
+  border-style: solid;
+  border-radius: 3px;
+  margin-left: 1px;
+  margin-right: 1px; }
+
+gstyleslidein #scale_box button.toggle:checked,
+gstyleslidein #strings_controls button.toggle:checked,
+gstyleslidein #palette_controls button.toggle:checked,
+gstyleslidein #components_controls button.toggle:checked {
+  color: #5c616c; }
+
+configurationview entry.flat {
+  background: none; }
+
+configurationview list {
+  border-width: 0; }
 
 .documents-scrolledwin.frame {
   border-width: 0; }
@@ -3400,46 +3399,119 @@ button.documents-favorite:active:hover {
   opacity: 0.0;
   transition: opacity 0.2s ease-out; }
 
+.tweak-categories,
+.tweak-category:not(:selected):not(:hover) {
+  background-image: linear-gradient(to bottom, #ffffff, #ffffff); }
+
 .tr-workarea undershoot,
 .tr-workarea overshoot {
   border-color: transparent; }
 
-.gnome-panel-menu-bar, .gnome-panel-menu-bar menubar,
-.mate-panel-menu-bar,
-.mate-panel-menu-bar menubar {
+.atril-window .primary-toolbar toolbar, .atril-window .primary-toolbar .inline-toolbar {
+  background: none; }
+
+#gf-bubble, #gf-bubble.solid,
+#gf-osd-window,
+#gf-osd-window.solid,
+#gf-input-source-popup,
+#gf-input-source-popup.solid,
+#gf-candidate-popup,
+#gf-candidate-popup.solid {
+  color: #cfd5de;
+  background-color: #353945;
+  border: 1px solid #23262e;
+  border-radius: 2px; }
+
+#gf-bubble levelbar block.low, #gf-bubble levelbar block.high, #gf-bubble levelbar block.full,
+#gf-osd-window levelbar block.low,
+#gf-osd-window levelbar block.high,
+#gf-osd-window levelbar block.full,
+#gf-input-source-popup levelbar block.low,
+#gf-input-source-popup levelbar block.high,
+#gf-input-source-popup levelbar block.full,
+#gf-candidate-popup levelbar block.low,
+#gf-candidate-popup levelbar block.high,
+#gf-candidate-popup levelbar block.full {
+  background-color: #cc575d;
+  border-color: #cc575d; }
+
+#gf-bubble levelbar block.empty,
+#gf-osd-window levelbar block.empty,
+#gf-input-source-popup levelbar block.empty,
+#gf-candidate-popup levelbar block.empty {
+  background-color: #2a2d37; }
+
+#gf-bubble levelbar trough,
+#gf-osd-window levelbar trough,
+#gf-input-source-popup levelbar trough,
+#gf-candidate-popup levelbar trough {
+  background: none; }
+
+#gf-input-source {
+  min-height: 32px;
+  min-width: 40px; }
+  #gf-input-source:selected {
+    color: #ffffff;
+    background-color: #cc575d;
+    border-radius: 2px; }
+
+gf-candidate-box label {
+  padding: 3px; }
+
+gf-candidate-box:hover, gf-candidate-box:selected {
+  color: #ffffff;
+  background-color: #cc575d;
+  border-radius: 2px; }
+
+MsdOsdWindow.background.osd {
+  border-radius: 2px;
+  border: 1px solid #23262e; }
+  MsdOsdWindow.background.osd .progressbar {
+    background-color: #cc575d;
+    border: none;
+    border-color: red;
+    border-radius: 5px; }
+  MsdOsdWindow.background.osd .trough {
+    background-color: #2a2d37;
+    border: none;
+    border-radius: 5px; }
+
+.mate-panel-menu-bar, .mate-panel-menu-bar menubar,
+panel-toplevel.background,
+panel-toplevel.background menubar {
   background-color: #2b2e37; }
 
-.gnome-panel-menu-bar menubar,
-.gnome-panel-menu-bar #PanelApplet label,
-.gnome-panel-menu-bar #PanelApplet image,
 .mate-panel-menu-bar menubar,
 .mate-panel-menu-bar #PanelApplet label,
-.mate-panel-menu-bar #PanelApplet image {
+.mate-panel-menu-bar #PanelApplet image,
+panel-toplevel.background menubar,
+panel-toplevel.background #PanelApplet label,
+panel-toplevel.background #PanelApplet image {
   color: #BAC3CF; }
 
-.gnome-panel-menu-bar button label, .gnome-panel-menu-bar button image,
-.gnome-panel-menu-bar #tasklist-button label,
-.gnome-panel-menu-bar #tasklist-button image,
-.mate-panel-menu-bar button label,
-.mate-panel-menu-bar button image,
+.mate-panel-menu-bar button label, .mate-panel-menu-bar button image,
 .mate-panel-menu-bar #tasklist-button label,
-.mate-panel-menu-bar #tasklist-button image {
+.mate-panel-menu-bar #tasklist-button image,
+panel-toplevel.background button label,
+panel-toplevel.background button image,
+panel-toplevel.background #tasklist-button label,
+panel-toplevel.background #tasklist-button image {
   color: inherit; }
 
-.gnome-panel-menu-bar .wnck-pager,
-.mate-panel-menu-bar .wnck-pager {
+.mate-panel-menu-bar .wnck-pager,
+panel-toplevel.background .wnck-pager {
   color: #5d6268;
   background-color: #14161b; }
-  .gnome-panel-menu-bar .wnck-pager:hover,
-  .mate-panel-menu-bar .wnck-pager:hover {
+  .mate-panel-menu-bar .wnck-pager:hover,
+  panel-toplevel.background .wnck-pager:hover {
     background-color: #363a46; }
-  .gnome-panel-menu-bar .wnck-pager:selected,
-  .mate-panel-menu-bar .wnck-pager:selected {
+  .mate-panel-menu-bar .wnck-pager:selected,
+  panel-toplevel.background .wnck-pager:selected {
     color: #e4a5a8;
     background-color: #cc575d; }
 
-.gnome-panel-menu-bar na-tray-applet,
-.mate-panel-menu-bar na-tray-applet {
+.mate-panel-menu-bar na-tray-applet,
+panel-toplevel.background na-tray-applet {
   -NaTrayApplet-icon-padding: 0;
   -NaTrayApplet-icon-size: 16px; }
 
@@ -3457,26 +3529,32 @@ button.documents-favorite:active:hover {
     color: #d8dde4;
     background-color: rgba(0, 0, 0, 0.17); }
   #tasklist-button:checked {
-    color: #ffffff;
+    color: white;
     background-color: rgba(0, 0, 0, 0.25);
     box-shadow: inset 0 -2px #cc575d; }
 
-.gnome-panel-menu-bar button:not(#tasklist-button),
-.mate-panel-menu-bar button:not(#tasklist-button), .xfce4-panel.panel button.flat, .xfce4-panel.panel button.sidebar-button {
+.mate-panel-menu-bar button:not(#tasklist-button),
+panel-toplevel.background button:not(#tasklist-button), .xfce4-panel.panel button.flat, .xfce4-panel.panel button.sidebar-button {
   color: #BAC3CF;
   border-radius: 0;
   border: none;
   background-color: rgba(43, 46, 55, 0); }
-  .gnome-panel-menu-bar button:hover:not(#tasklist-button),
-  .mate-panel-menu-bar button:hover:not(#tasklist-button), .xfce4-panel.panel button.flat:hover, .xfce4-panel.panel button.sidebar-button:hover {
+  .mate-panel-menu-bar button:hover:not(#tasklist-button),
+  panel-toplevel.background button:hover:not(#tasklist-button), .xfce4-panel.panel button.flat:hover, .xfce4-panel.panel button.sidebar-button:hover {
     border: none;
     background-color: #414654; }
-  .gnome-panel-menu-bar button:active:not(#tasklist-button),
-  .mate-panel-menu-bar button:active:not(#tasklist-button), .xfce4-panel.panel button.flat:active, .xfce4-panel.panel button.sidebar-button:active, .gnome-panel-menu-bar button:checked:not(#tasklist-button),
-  .mate-panel-menu-bar button:checked:not(#tasklist-button), .xfce4-panel.panel button.flat:checked, .xfce4-panel.panel button.sidebar-button:checked {
+  .mate-panel-menu-bar button:active:not(#tasklist-button),
+  panel-toplevel.background button:active:not(#tasklist-button), .xfce4-panel.panel button.flat:active, .xfce4-panel.panel button.sidebar-button:active, .mate-panel-menu-bar button:checked:not(#tasklist-button),
+  panel-toplevel.background button:checked:not(#tasklist-button), .xfce4-panel.panel button.flat:checked, .xfce4-panel.panel button.sidebar-button:checked {
     color: #ffffff;
     border: none;
     background-color: #cc575d; }
+    .mate-panel-menu-bar button:active:not(#tasklist-button) label,
+    panel-toplevel.background button:active:not(#tasklist-button) label, .xfce4-panel.panel button.flat:active label, .xfce4-panel.panel button.sidebar-button:active label, .mate-panel-menu-bar button:active:not(#tasklist-button) image,
+    panel-toplevel.background button:active:not(#tasklist-button) image, .xfce4-panel.panel button.flat:active image, .xfce4-panel.panel button.sidebar-button:active image, .mate-panel-menu-bar button:checked:not(#tasklist-button) label,
+    panel-toplevel.background button:checked:not(#tasklist-button) label, .xfce4-panel.panel button.flat:checked label, .xfce4-panel.panel button.sidebar-button:checked label, .mate-panel-menu-bar button:checked:not(#tasklist-button) image,
+    panel-toplevel.background button:checked:not(#tasklist-button) image, .xfce4-panel.panel button.flat:checked image, .xfce4-panel.panel button.sidebar-button:checked image {
+      color: inherit; }
 
 .nautilus-window .floating-bar {
   padding: 1px;
@@ -3498,17 +3576,17 @@ button.documents-favorite:active:hover {
   padding-right: 4px;
   color: rgba(82, 93, 118, 0.8);
   border-color: rgba(82, 93, 118, 0.1);
-  background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.9));
-  background-color: transparent; }
+  background-color: rgba(255, 255, 255, 0.9); }
   .marlin-pathbar.pathbar image, .marlin-pathbar.pathbar image:hover {
     color: inherit; }
   .marlin-pathbar.pathbar:focus {
     color: #ffffff;
     border-color: #cc575d;
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
   .marlin-pathbar.pathbar:disabled {
     color: rgba(82, 93, 118, 0.35);
-    background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.75)); }
+    border-color: rgba(82, 93, 118, 0.1);
+    background-color: rgba(255, 255, 255, 0.75); }
   .marlin-pathbar.pathbar:active, .marlin-pathbar.pathbar:checked {
     color: #cc575d; }
 
@@ -3516,7 +3594,7 @@ button.documents-favorite:active:hover {
   border: 1px solid rgba(0, 0, 0, 0.35);
   border-radius: 3px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  background-image: linear-gradient(to bottom, white);
+  background-image: linear-gradient(to bottom, white, white);
   background-color: transparent; }
   .gala-notification .title, .gala-notification .label {
     color: #5c616c; }
@@ -3583,24 +3661,25 @@ UnityDecoration {
   -UnityDecoration-title-indent: 10px;
   -UnityDecoration-title-fade: 35px;
   -UnityDecoration-title-alignment: 0.0; }
-  UnityDecoration.top {
+  UnityDecoration .top {
     border: 1px solid rgba(0, 0, 0, 0.1);
     border-bottom-width: 0;
     border-radius: 4px 4px 0 0;
     padding: 1px 6px 0 6px;
-    background-image: linear-gradient(to bottom, #e7e8eb);
+    background-image: linear-gradient(to bottom, #e7e8eb, #e7e8eb);
     color: rgba(82, 93, 118, 0.8);
     box-shadow: inset 0 1px #eff0f2; }
-    UnityDecoration.top:backdrop {
+    UnityDecoration .top:backdrop {
       border-bottom-width: 0;
       color: rgba(82, 93, 118, 0.5); }
-  UnityDecoration.left, UnityDecoration.right, UnityDecoration.bottom, UnityDecoration.left:backdrop, UnityDecoration.right:backdrop, UnityDecoration.bottom:backdrop {
+  UnityDecoration .left, UnityDecoration .right, UnityDecoration .bottom,
+  UnityDecoration .left:backdrop, UnityDecoration .right:backdrop, UnityDecoration .bottom:backdrop {
     background-color: transparent;
-    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.1)); }
+    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1)); }
 
 UnityPanelWidget,
 .unity-panel {
-  background-image: linear-gradient(to bottom, #2f343f);
+  background-image: linear-gradient(to bottom, #2f343f, #2f343f);
   color: #f6f7f9;
   box-shadow: none; }
   UnityPanelWidget:backdrop,
@@ -3611,7 +3690,7 @@ UnityPanelWidget,
 .unity-panel.menubar .menuitem *:hover {
   border-radius: 0;
   color: #ffffff;
-  background-image: linear-gradient(to bottom, #cc575d);
+  background-image: linear-gradient(to bottom, #cc575d, #cc575d);
   border-bottom: none; }
 
 .lightdm.menu {
@@ -3804,7 +3883,7 @@ GraniteWidgetsWelcome {
 
 GraniteWidgetsWelcome label {
   color: #a9acb2;
-  font: open sans 11;
+  font-size: 11px;
   text-shadow: none; }
 
 GraniteWidgetsWelcome .h1,
@@ -3824,7 +3903,7 @@ GraniteWidgetsPopOver {
   margin: 0; }
 
 .popover_bg {
-  background-image: linear-gradient(to bottom, #ffffff);
+  background-image: linear-gradient(to bottom, #ffffff, #ffffff);
   border: 1px solid rgba(0, 0, 0, 0.3); }
 
 GraniteWidgetsPopOver .sidebar.view, GraniteWidgetsPopOver iconview.sidebar,
@@ -3835,13 +3914,13 @@ GraniteWidgetsXsEntry entry {
   padding: 4px; }
 
 .h1 {
-  font: open sans 24px; }
+  font-size: 24px; }
 
 .h2 {
-  font: open sans light 18px; }
+  font-size: 18px; }
 
 .h3 {
-  font: open sans 11px; }
+  font-size: 11px; }
 
 .h4,
 .category-label {
@@ -3858,24 +3937,25 @@ GtkListBox .h4 {
 #panel_window {
   background-color: #2b2e37;
   color: #BAC3CF;
-  font: bold;
+  font-weight: bold;
   box-shadow: inset 0 -1px #1b1d23; }
-  #panel_window menubar,
-  #panel_window menubar > menuitem {
-    background-color: transparent;
-    color: #BAC3CF;
-    font: bold; }
+  #panel_window menubar {
+    padding-left: 5px; }
+    #panel_window menubar, #panel_window menubar > menuitem {
+      background-color: transparent;
+      color: #BAC3CF;
+      font-weight: bold; }
   #panel_window menubar menuitem:disabled {
     color: rgba(186, 195, 207, 0.5); }
     #panel_window menubar menuitem:disabled label {
       color: inherit; }
   #panel_window menubar menu > menuitem {
-    font: normal; }
+    font-weight: normal; }
 
 #login_window,
 #shutdown_dialog,
 #restart_dialog {
-  font: normal;
+  font-weight: normal;
   border-style: none;
   background-color: transparent;
   color: #5c616c; }
@@ -3890,17 +3970,14 @@ GtkListBox .h4 {
 
 #content_frame button {
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: #fbfbfc; }
   #content_frame button:hover {
     color: #5c616c;
-    outline-color: rgba(92, 97, 108, 0.3);
     border-color: #cfd6e6;
     background-color: white; }
   #content_frame button:active, #content_frame button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d; }
   #content_frame button:disabled {
@@ -3922,17 +3999,14 @@ GtkListBox .h4 {
 
 #buttonbox_frame button {
   color: #BAC3CF;
-  outline-color: rgba(186, 195, 207, 0.3);
   border-color: rgba(26, 28, 34, 0.4);
   background-color: rgba(102, 109, 132, 0.4); }
   #buttonbox_frame button:hover {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: rgba(119, 127, 151, 0.5); }
   #buttonbox_frame button:active, #buttonbox_frame button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: #cc575d; }
   #buttonbox_frame button:disabled {
@@ -3942,9 +4016,9 @@ GtkListBox .h4 {
 
 #login_window #user_combobox {
   color: #5c616c;
-  font: 13px; }
+  font-size: 13px; }
   #login_window #user_combobox menu {
-    font: normal; }
+    font-weight: normal; }
 
 #user_image {
   padding: 3px;
@@ -3952,55 +4026,49 @@ GtkListBox .h4 {
 
 #shutdown_button.button {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
+  color: green;
   background-color: #F04A50;
   border-color: #F04A50; }
   #shutdown_button.button:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #f4797e;
     border-color: #f4797e; }
   #shutdown_button.button:active, #shutdown_button.button:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #ec1b22;
     border-color: #ec1b22; }
 
 #restart_button.button {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
-  background-color: #be3941;
-  border-color: #be3941; }
+  color: green;
+  background-color: #BE3941;
+  border-color: #BE3941; }
   #restart_button.button:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #ce5c63;
     border-color: #ce5c63; }
   #restart_button.button:active, #restart_button.button:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #972d34;
     border-color: #972d34; }
 
 #greeter_infobar {
   border-bottom-width: 0;
-  font: bold; }
+  font-weight: bold; }
 
 .nautilus-window paned > separator {
-  background-image: linear-gradient(to top, #353945); }
+  background-image: linear-gradient(to bottom, #353945, #353945); }
   .nautilus-window paned > separator:dir(ltr) {
     margin-left: -1px; }
   .nautilus-window paned > separator:dir(rtl) {
     margin-right: -1px; }
 
 filechooser paned > separator {
-  background-image: linear-gradient(to top, #353945); }
+  background-image: linear-gradient(to bottom, #353945, #353945); }
 
 filechooser.csd.background, filechooser placessidebar list,
 .nautilus-window.csd.background,
@@ -4038,13 +4106,11 @@ filechooser placessidebar.sidebar,
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:hover,
       .nautilus-window placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:hover {
         color: #BAC3CF;
-        outline-color: rgba(186, 195, 207, 0.3);
         border-color: rgba(26, 28, 34, 0.4);
         background-color: rgba(119, 127, 151, 0.5); }
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:active,
       .nautilus-window placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:active {
         color: #ffffff;
-        outline-color: rgba(255, 255, 255, 0.3);
         border-color: #cc575d;
         background-color: #cc575d; }
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:not(:hover):not(:active) > image,
@@ -4120,6 +4186,12 @@ filechooser actionbar {
 .gedit-bottom-panel-paned {
   background-color: #ffffff; }
 
+.gedit-side-panel-paned > separator {
+  background-image: linear-gradient(to bottom, #353945, #353945); }
+
+.gedit-bottom-panel-paned > separator {
+  background-image: linear-gradient(to bottom, #dcdfe3, #dcdfe3); }
+
 .gedit-document-panel {
   background-color: #353945; }
   .maximized .gedit-document-panel {
@@ -4142,17 +4214,14 @@ filechooser actionbar {
 
 filechooser actionbar button {
   color: #BAC3CF;
-  outline-color: rgba(186, 195, 207, 0.3);
   border-color: rgba(26, 28, 34, 0.4);
   background-color: rgba(102, 109, 132, 0.4); }
   .caja-side-pane > box button:hover:not(:active), filechooser actionbar button:hover {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: rgba(119, 127, 151, 0.5); }
   filechooser actionbar button:active, filechooser actionbar button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: rgba(26, 28, 34, 0.4);
     background-color: #cc575d; }
   filechooser actionbar button:disabled {
@@ -4163,17 +4232,16 @@ filechooser actionbar button {
 filechooser actionbar entry {
   color: #BAC3CF;
   border-color: rgba(26, 28, 34, 0.4);
-  background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.4));
-  background-color: transparent; }
+  background-color: rgba(102, 109, 132, 0.4); }
   filechooser actionbar entry image, filechooser actionbar entry image:hover {
     color: inherit; }
   filechooser actionbar entry:focus {
     color: #ffffff;
     border-color: rgba(26, 28, 34, 0.4);
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
   filechooser actionbar entry:disabled {
     color: rgba(186, 195, 207, 0.55);
-    background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.25)); }
+    background-color: rgba(102, 109, 132, 0.25); }
 
 filechooser placessidebar.sidebar scrollbar,
 .nautilus-window placessidebar.sidebar scrollbar, .nemo-window .sidebar scrollbar, .caja-side-pane scrollbar {

--- a/common/gtk-3.0/3.20/gtk.css
+++ b/common/gtk-3.0/3.20/gtk.css
@@ -4,13 +4,11 @@
   -GtkTextView-error-underline-color: #FC4138;
   -GtkScrolledWindow-scrollbar-spacing: 0;
   -GtkToolItemGroup-expander-size: 11;
-  -GtkTreeView-expander-size: 11;
-  -GtkTreeView-horizontal-separator: 4;
   -GtkWidget-text-handle-width: 20;
   -GtkWidget-text-handle-height: 20;
   -GtkDialog-button-spacing: 4;
   -GtkDialog-action-area-border: 0;
-  outline-color: rgba(92, 97, 108, 0.3);
+  outline-color: alpha(currentColor,0.3);
   outline-style: dashed;
   outline-offset: -3px;
   outline-width: 1px;
@@ -107,7 +105,6 @@ popover.background.magnifier, .csd popover.background.osd, .csd popover.backgrou
   border: none;
   background-color: rgba(53, 57, 69, 0.95);
   background-clip: padding-box;
-  outline-color: rgba(186, 195, 207, 0.3);
   box-shadow: none; }
 
 @keyframes spin {
@@ -133,8 +130,7 @@ entry {
   transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
   color: #5c616c;
   border-color: #cfd6e6;
-  background-color: #ffffff;
-  background-image: linear-gradient(to bottom, #ffffff); }
+  background-color: #ffffff; }
   entry.search {
     border-radius: 20px; }
   entry image {
@@ -155,51 +151,49 @@ entry {
     background-clip: border-box;
     color: #5c616c;
     border-color: #cc575d;
-    background-color: #ffffff;
-    background-image: linear-gradient(to bottom, #ffffff); }
+    background-color: #ffffff; }
   entry:disabled {
     color: rgba(92, 97, 108, 0.55);
     border-color: rgba(207, 214, 230, 0.55);
-    background-color: rgba(255, 255, 255, 0.55);
-    background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.55)); }
+    background-color: rgba(255, 255, 255, 0.55); }
   entry.warning {
-    color: #ffffff;
+    color: white;
     border-color: #F27835;
-    background-image: linear-gradient(to bottom, #f7ae86); }
+    background-color: #f7ae86; }
     entry.warning image {
-      color: #ffffff; }
+      color: white; }
     entry.warning:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #F27835);
+      color: white;
+      background-color: #F27835;
       box-shadow: none; }
     entry.warning selection, entry.warning selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #F27835; }
   entry.error {
-    color: #ffffff;
+    color: white;
     border-color: #FC4138;
-    background-image: linear-gradient(to bottom, #fd8d88); }
+    background-color: #fd8d88; }
     entry.error image {
-      color: #ffffff; }
+      color: white; }
     entry.error:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138);
+      color: white;
+      background-color: #FC4138;
       box-shadow: none; }
     entry.error selection, entry.error selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
   entry.search-missing {
-    color: #ffffff;
+    color: white;
     border-color: #FC4138;
-    background-image: linear-gradient(to bottom, #fd8d88); }
+    background-color: #fd8d88; }
     entry.search-missing image {
-      color: #ffffff; }
+      color: white; }
     entry.search-missing:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138);
+      color: white;
+      background-color: #FC4138;
       box-shadow: none; }
     entry.search-missing selection, entry.search-missing selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
   entry:drop(active):focus, entry:drop(active) {
     border-color: #F08437;
@@ -207,17 +201,16 @@ entry {
   .osd entry {
     color: #BAC3CF;
     border-color: rgba(26, 28, 34, 0.35);
-    background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.35));
-    background-color: transparent; }
+    background-color: rgba(102, 109, 132, 0.35); }
     .osd entry image, .osd entry image:hover {
       color: inherit; }
     .osd entry:focus {
       color: #ffffff;
       border-color: rgba(26, 28, 34, 0.35);
-      background-image: linear-gradient(to bottom, #cc575d); }
+      background-color: #cc575d; }
     .osd entry:disabled {
       color: rgba(186, 195, 207, 0.55);
-      background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.2)); }
+      background-color: rgba(102, 109, 132, 0.2); }
     .osd entry selection:focus, .osd entry selection {
       color: #cc575d;
       background-color: #ffffff; }
@@ -252,7 +245,6 @@ button {
   border-radius: 3px;
   padding: 2px 6px;
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: #fbfbfc; }
   button separator {
@@ -269,17 +261,18 @@ button {
         transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   button:hover {
     color: #5c616c;
-    outline-color: rgba(92, 97, 108, 0.3);
     border-color: #cfd6e6;
     background-color: white;
     -gtk-icon-effect: highlight; }
   button:active, button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d;
     background-clip: border-box;
     transition-duration: 50ms; }
+    button:active:not(:disabled) label:disabled, button:checked:not(:disabled) label:disabled {
+      color: inherit;
+      opacity: 0.6; }
   button:active {
     color: #5c616c; }
   button:active:hover, button:checked {
@@ -327,7 +320,6 @@ button {
     box-shadow: none; }
   button.osd {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     background-color: rgba(53, 57, 69, 0.95);
     border-color: rgba(35, 38, 46, 0.95); }
     button.osd.image-button {
@@ -338,7 +330,6 @@ button {
       color: #cc575d; }
     button.osd:active, button.osd:checked {
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.35);
       background-color: #cc575d; }
     button.osd:disabled {
@@ -347,18 +338,15 @@ button {
       background-color: rgba(102, 109, 132, 0.2); }
   .osd button {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: rgba(102, 109, 132, 0.35); }
     .osd button:hover {
       color: #BAC3CF;
-      outline-color: rgba(186, 195, 207, 0.3);
       border-color: rgba(26, 28, 34, 0.35);
       background-color: rgba(119, 127, 151, 0.45); }
     .osd button:active, .osd button:checked {
       background-clip: padding-box;
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.35);
       background-color: #cc575d; }
     .osd button:disabled {
@@ -372,7 +360,6 @@ button {
       box-shadow: none; }
       .osd button.flat:hover, .osd button.sidebar-button:hover {
         color: #BAC3CF;
-        outline-color: rgba(186, 195, 207, 0.3);
         border-color: rgba(26, 28, 34, 0.35);
         background-color: rgba(119, 127, 151, 0.45); }
       .osd button.flat:disabled, .osd button.sidebar-button:disabled {
@@ -382,7 +369,6 @@ button {
         background-image: none; }
       .osd button.flat:active, .osd button.sidebar-button:active, .osd button.flat:checked, .osd button.sidebar-button:checked {
         color: #ffffff;
-        outline-color: rgba(255, 255, 255, 0.3);
         border-color: rgba(26, 28, 34, 0.35);
         background-color: #cc575d; }
   .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active):not(:only-child),
@@ -390,26 +376,22 @@ button {
     box-shadow: none; }
   button.suggested-action {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
-    background-color: #be3941;
-    border-color: #be3941; }
+    color: white;
+    background-color: #BE3941;
+    border-color: #BE3941; }
     button.suggested-action.flat, button.suggested-action.sidebar-button {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
-      color: #be3941;
-      outline-color: rgba(190, 57, 65, 0.3); }
+      color: #BE3941; }
     button.suggested-action:hover {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #ce5c63;
       border-color: #ce5c63; }
     button.suggested-action:active, button.suggested-action:checked {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #972d34;
       border-color: #972d34; }
     button.suggested-action.flat:disabled, button.suggested-action.sidebar-button:disabled {
@@ -424,26 +406,22 @@ button {
         color: rgba(92, 97, 108, 0.55); }
   button.destructive-action {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #F04A50;
     border-color: #F04A50; }
     button.destructive-action.flat, button.destructive-action.sidebar-button {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
-      color: #F04A50;
-      outline-color: rgba(240, 74, 80, 0.3); }
+      color: #F04A50; }
     button.destructive-action:hover {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #f4797e;
       border-color: #f4797e; }
     button.destructive-action:active, button.destructive-action:checked {
       background-clip: border-box;
-      color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
+      color: white;
       background-color: #ec1b22;
       border-color: #ec1b22; }
     button.destructive-action.flat:disabled, button.destructive-action.sidebar-button:disabled {
@@ -483,23 +461,22 @@ button {
     background-position: right 3px, right 4px; }
     .stack-switcher > button.needs-attention > label:dir(rtl), .stack-switcher > button.needs-attention > image:dir(rtl), button stacksidebar row.needs-attention > label:dir(rtl), stacksidebar button row.needs-attention > label:dir(rtl) {
       background-position: left 3px, left 4px; }
+  button.font separator, button.file separator {
+    background-color: transparent; }
   .inline-toolbar button, .inline-toolbar button:backdrop {
     border-radius: 2px;
     border-width: 1px; }
 
 .inline-toolbar toolbutton > button {
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: #fbfbfc; }
   .inline-toolbar toolbutton > button:hover {
     color: #5c616c;
-    outline-color: rgba(92, 97, 108, 0.3);
     border-color: #cfd6e6;
     background-color: white; }
   .inline-toolbar toolbutton > button:active, .inline-toolbar toolbutton > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d; }
   .inline-toolbar toolbutton > button:disabled {
@@ -576,12 +553,23 @@ button {
 .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
   box-shadow: inset 1px 0 #cfd6e6; }
 
-.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
+  box-shadow: inset 1px 0 rgba(207, 214, 230, 0.5); }
+
 .linked:not(.vertical):not(.path-bar) > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked:not(.vertical):not(.path-bar) > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
-.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child) {
+.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:disabled,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked:not(.vertical):not(.path-bar) > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked:not(.vertical):not(.path-bar) > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child) {
   box-shadow: none; }
 
 .linked:not(.vertical).path-bar > button + button {
@@ -658,12 +646,23 @@ button {
 .linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
   box-shadow: inset 0 1px #cfd6e6; }
 
-.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
+  box-shadow: inset 0 1px rgba(207, 214, 230, 0.5); }
+
 .linked.vertical > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
 .linked.vertical > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover,
-.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child) {
+.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:disabled,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):first-child:hover,
+.linked.vertical > button:active + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button:checked + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button.suggested-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > button.destructive-action + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled,
+.linked.vertical > entry + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child) {
   box-shadow: none; }
 
 toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat, toolbar.inline-toolbar toolbutton > button.sidebar-button, .inline-toolbar toolbutton > button.sidebar-button, .linked:not(.vertical) > entry,
@@ -709,7 +708,7 @@ toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > bu
   border-style: solid; }
 
 menuitem.button.flat,
-modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover, .app-notification button.flat, .app-notification button.sidebar-button, .app-notification button.flat:disabled, .app-notification button.sidebar-button:disabled {
+modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover, .app-notification button.flat, .app-notification button.sidebar-button, .app-notification button.flat:disabled, .app-notification button.sidebar-button:disabled, calendar.button {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
@@ -760,16 +759,7 @@ modelbutton.flat arrow.right {
     color: #b8383e; }
     *:selected *:link:active, *:selected button:active:link, *:selected button:active:visited {
       color: #f5dddf; }
-  .info *:link, .info button:link, .info button:visited,
-  .question *:link,
-  .question button:link,
-  .question button:visited,
-  .warning *:link,
-  .warning button:link,
-  .warning button:visited,
-  .error *:link,
-  .error button:link,
-  .error button:visited, *:link:selected, button:selected:link, button:selected:visited, headerbar.selection-mode .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link,
+  infobar.info *:link, infobar.info button:link, infobar.info button:visited, infobar.question *:link, infobar.question button:link, infobar.question button:visited, infobar.warning *:link, infobar.warning button:link, infobar.warning button:visited, infobar.error *:link, infobar.error button:link, infobar.error button:visited, *:link:selected, button:selected:link, button:selected:visited, headerbar.selection-mode .subtitle:link, .selection-mode.titlebar:not(headerbar) .subtitle:link,
   *:selected *:link,
   *:selected button:link,
   *:selected button:visited {
@@ -800,6 +790,10 @@ spinbutton:not(.vertical) > button + button {
 spinbutton:not(.vertical) > button:hover:not(:active),
 spinbutton:not(.vertical) > button:hover + button {
   box-shadow: inset 1px 0 #cfd6e6; }
+
+spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover),
+spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled {
+  box-shadow: inset 1px 0 rgba(207, 214, 230, 0.5); }
 
 spinbutton:not(.vertical) > button:first-child:hover:not(:active),
 spinbutton:not(.vertical) > button.up:dir(rtl):hover:not(:active),
@@ -886,7 +880,7 @@ toolbar, .inline-toolbar {
   toolbar:not(.inline-toolbar) .linked > entry, .inline-toolbar:not(.inline-toolbar) .linked > entry {
     margin-right: 0; }
 
-.primary-toolbar {
+.primary-toolbar:not(.libreoffice-toolbar) {
   color: rgba(82, 93, 118, 0.8);
   background-color: #e7e8eb;
   box-shadow: none;
@@ -1032,22 +1026,21 @@ window.csd > .titlebar:not(headerbar):backdrop {
   box-shadow: none; }
 
 .titlebar:not(headerbar) > separator {
-  background-image: linear-gradient(to top, rgba(212, 213, 219, 0.95)); }
+  background-image: linear-gradient(to bottom, rgba(212, 213, 219, 0.95), rgba(212, 213, 219, 0.95)); }
 
-.primary-toolbar separator, headerbar separator.titlebutton, .titlebar:not(headerbar) separator.titlebutton {
+.primary-toolbar:not(.libreoffice-toolbar) separator, headerbar separator.titlebutton, .titlebar:not(headerbar) separator.titlebutton {
   min-width: 1px;
   min-height: 1px;
   background: none;
   border-width: 0 1px;
   border-image: linear-gradient(to bottom, rgba(82, 93, 118, 0) 25%, rgba(82, 93, 118, 0.15) 25%, rgba(82, 93, 118, 0.15) 75%, rgba(82, 93, 118, 0) 75%) 0 1/0 1px stretch; }
-  .primary-toolbar separator:backdrop, headerbar separator.titlebutton:backdrop, .titlebar:not(headerbar) separator.titlebutton:backdrop {
+  .primary-toolbar:not(.libreoffice-toolbar) separator:backdrop, headerbar separator.titlebutton:backdrop, .titlebar:not(headerbar) separator.titlebutton:backdrop {
     opacity: 0.6; }
 
 .primary-toolbar entry, headerbar entry {
   color: rgba(82, 93, 118, 0.8);
   border-color: rgba(82, 93, 118, 0.1);
-  background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.9));
-  background-color: transparent; }
+  background-color: rgba(255, 255, 255, 0.9); }
   .primary-toolbar entry image, headerbar entry image, .primary-toolbar entry image:hover, headerbar entry image:hover {
     color: inherit; }
   .primary-toolbar entry:backdrop, headerbar entry:backdrop {
@@ -1055,13 +1048,14 @@ window.csd > .titlebar:not(headerbar):backdrop {
   .primary-toolbar entry:focus, headerbar entry:focus {
     color: #ffffff;
     border-color: #cc575d;
-    background-image: linear-gradient(to bottom, #cc575d);
+    background-color: #cc575d;
     background-clip: border-box; }
     .primary-toolbar entry:focus image, headerbar entry:focus image {
       color: #ffffff; }
   .primary-toolbar entry:disabled, headerbar entry:disabled {
     color: rgba(82, 93, 118, 0.35);
-    background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.75)); }
+    border-color: rgba(82, 93, 118, 0.1);
+    background-color: rgba(255, 255, 255, 0.75); }
   .primary-toolbar entry selection:focus, headerbar entry selection:focus {
     background-color: #ffffff;
     color: #cc575d; }
@@ -1070,29 +1064,28 @@ window.csd > .titlebar:not(headerbar):backdrop {
     background-image: none;
     background-color: transparent; }
   .primary-toolbar entry.warning, headerbar entry.warning {
-    color: #ffffff;
+    color: white;
     border-color: #F27835;
-    background-image: linear-gradient(to bottom, rgba(238, 162, 121, 0.98)); }
+    background-color: rgba(238, 162, 121, 0.98); }
     .primary-toolbar entry.warning:focus, headerbar entry.warning:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #F27835); }
+      color: white;
+      background-color: #F27835; }
     .primary-toolbar entry.warning selection, headerbar entry.warning selection, .primary-toolbar entry.warning selection:focus, headerbar entry.warning selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #F27835; }
   .primary-toolbar entry.error, headerbar entry.error {
-    color: #ffffff;
+    color: white;
     border-color: #FC4138;
-    background-image: linear-gradient(to bottom, rgba(244, 128, 123, 0.98)); }
+    background-color: rgba(244, 128, 123, 0.98); }
     .primary-toolbar entry.error:focus, headerbar entry.error:focus {
-      color: #ffffff;
-      background-image: linear-gradient(to bottom, #FC4138); }
+      color: white;
+      background-color: #FC4138; }
     .primary-toolbar entry.error selection, headerbar entry.error selection, .primary-toolbar entry.error selection:focus, headerbar entry.error selection:focus {
-      background-color: #ffffff;
+      background-color: white;
       color: #FC4138; }
 
 .primary-toolbar button, headerbar button {
   color: rgba(82, 93, 118, 0.8);
-  outline-color: rgba(82, 93, 118, 0.1);
   outline-offset: -3px;
   background-color: rgba(231, 232, 235, 0);
   border-color: rgba(231, 232, 235, 0); }
@@ -1100,12 +1093,10 @@ window.csd > .titlebar:not(headerbar):backdrop {
     opacity: 0.7; }
   .primary-toolbar button:hover, headerbar button:hover {
     color: rgba(82, 93, 118, 0.8);
-    outline-color: rgba(82, 93, 118, 0.1);
     border-color: rgba(82, 93, 118, 0.1);
     background-color: rgba(251, 251, 252, 0.9); }
   .primary-toolbar button:active, headerbar button:active, .primary-toolbar button:checked, headerbar button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d;
     background-clip: border-box; }
@@ -1133,19 +1124,17 @@ window.csd > .titlebar:not(headerbar):backdrop {
   border-radius: 3px;
   border-style: solid; }
 
-.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) {
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
   box-shadow: none; }
 
 .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .linked:not(.vertical).path-bar > button, headerbar .linked:not(.vertical).path-bar > button {
   color: rgba(82, 93, 118, 0.8);
-  outline-color: rgba(82, 93, 118, 0.1);
   border-color: rgba(82, 93, 118, 0.1);
   background-color: rgba(251, 251, 252, 0.9); }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar .linked:not(.vertical).path-bar > button:hover, headerbar .linked:not(.vertical).path-bar > button:hover {
     background-color: rgba(255, 255, 255, 0.9); }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar .linked:not(.vertical).path-bar > button:active, headerbar .linked:not(.vertical).path-bar > button:active, .primary-toolbar .linked:not(.vertical).path-bar > button:checked, headerbar .linked:not(.vertical).path-bar > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d; }
   .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, .primary-toolbar .linked:not(.vertical).path-bar > button:disabled, headerbar .linked:not(.vertical).path-bar > button:disabled {
@@ -1204,26 +1193,22 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar button.suggested-action, headerbar button.suggested-action {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
-  background-color: #be3941;
-  border-color: #be3941; }
+  color: white;
+  background-color: #BE3941;
+  border-color: #BE3941; }
   .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat, .primary-toolbar button.suggested-action.sidebar-button, headerbar button.suggested-action.sidebar-button {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
-    color: #be3941;
-    outline-color: rgba(190, 57, 65, 0.3); }
+    color: #BE3941; }
   .primary-toolbar button.suggested-action:hover, headerbar button.suggested-action:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #ce5c63;
     border-color: #ce5c63; }
   .primary-toolbar button.suggested-action:active, headerbar button.suggested-action:active, .primary-toolbar button.suggested-action:checked, headerbar button.suggested-action:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #972d34;
     border-color: #972d34; }
   .primary-toolbar button.suggested-action.flat:disabled, headerbar button.suggested-action.flat:disabled, .primary-toolbar button.suggested-action.sidebar-button:disabled, headerbar button.suggested-action.sidebar-button:disabled, .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
@@ -1237,26 +1222,22 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar button.destructive-action, headerbar button.destructive-action {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
+  color: white;
   background-color: #F04A50;
   border-color: #F04A50; }
   .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat, .primary-toolbar button.destructive-action.sidebar-button, headerbar button.destructive-action.sidebar-button {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
-    color: #F04A50;
-    outline-color: rgba(240, 74, 80, 0.3); }
+    color: #F04A50; }
   .primary-toolbar button.destructive-action:hover, headerbar button.destructive-action:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #f4797e;
     border-color: #f4797e; }
   .primary-toolbar button.destructive-action:active, headerbar button.destructive-action:active, .primary-toolbar button.destructive-action:checked, headerbar button.destructive-action:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: white;
     background-color: #ec1b22;
     border-color: #ec1b22; }
   .primary-toolbar button.destructive-action.flat:disabled, headerbar button.destructive-action.flat:disabled, .primary-toolbar button.destructive-action.sidebar-button:disabled, headerbar button.destructive-action.sidebar-button:disabled, .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
@@ -1274,7 +1255,6 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar spinbutton:not(.vertical) button, headerbar spinbutton:not(.vertical) button, .primary-toolbar spinbutton:not(.vertical) button:disabled, headerbar spinbutton:not(.vertical) button:disabled {
   color: rgba(82, 93, 118, 0.8);
-  outline-color: rgba(82, 93, 118, 0.1);
   border-color: rgba(82, 93, 118, 0.1);
   background-color: rgba(251, 251, 252, 0.9); }
 
@@ -1283,7 +1263,6 @@ window.csd > .titlebar:not(headerbar):backdrop {
 
 .primary-toolbar spinbutton:not(.vertical) button:active, headerbar spinbutton:not(.vertical) button:active, .primary-toolbar spinbutton:not(.vertical) button:checked, headerbar spinbutton:not(.vertical) button:checked {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   border-color: #cc575d;
   background-color: #cc575d; }
 
@@ -1294,6 +1273,9 @@ window.csd > .titlebar:not(headerbar):backdrop {
   border-left-style: none; }
 
 .primary-toolbar spinbutton:not(.vertical) > button:hover:not(:active), headerbar spinbutton:not(.vertical) > button:hover:not(:active), .primary-toolbar spinbutton:not(.vertical) > button:hover + button, headerbar spinbutton:not(.vertical) > button:hover + button {
+  box-shadow: inset 1px 0 rgba(82, 93, 118, 0.1); }
+
+.primary-toolbar spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover), headerbar spinbutton:not(.vertical) > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover), .primary-toolbar spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled, headerbar spinbutton:not(.vertical) > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled {
   box-shadow: inset 1px 0 rgba(82, 93, 118, 0.1); }
 
 .primary-toolbar spinbutton:not(.vertical) > button:first-child:hover:not(:active), headerbar spinbutton:not(.vertical) > button:first-child:hover:not(:active), .primary-toolbar spinbutton:not(.vertical) > entry + button:not(:active):hover, headerbar spinbutton:not(.vertical) > entry + button:not(:active):hover {
@@ -1308,18 +1290,18 @@ window.csd > .titlebar:not(headerbar):backdrop {
 .primary-toolbar combobox > .linked > button.combo, headerbar combobox > .linked > button.combo {
   color: rgba(82, 93, 118, 0.8);
   border-color: rgba(82, 93, 118, 0.1);
-  background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.9));
-  background-color: transparent; }
+  background-color: rgba(255, 255, 255, 0.9); }
   .primary-toolbar combobox > .linked > button.combo image, headerbar combobox > .linked > button.combo image, .primary-toolbar combobox > .linked > button.combo image:hover, headerbar combobox > .linked > button.combo image:hover {
     color: inherit; }
   .primary-toolbar combobox > .linked > button.combo:hover, headerbar combobox > .linked > button.combo:hover {
     color: #ffffff;
     border-color: #cc575d;
-    background-image: linear-gradient(to bottom, #cc575d);
+    background-color: #cc575d;
     box-shadow: none; }
   .primary-toolbar combobox > .linked > button.combo:disabled, headerbar combobox > .linked > button.combo:disabled {
     color: rgba(82, 93, 118, 0.35);
-    background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.75)); }
+    border-color: rgba(82, 93, 118, 0.1);
+    background-color: rgba(255, 255, 255, 0.75); }
 
 .primary-toolbar combobox > .linked > entry.combo:dir(ltr), headerbar combobox > .linked > entry.combo:dir(ltr) {
   border-right-style: none; }
@@ -1396,13 +1378,15 @@ window.csd > .titlebar:not(headerbar):backdrop {
   padding-right: 4px; }
 
 treeview.view {
-  -GtkTreeView-grid-line-width: 1;
-  -GtkTreeView-grid-line-pattern: '';
-  -GtkTreeView-tree-line-width: 1;
-  -GtkTreeView-tree-line-pattern: '';
-  -GtkTreeView-expander-size: 16;
   border-left-color: rgba(92, 97, 108, 0.15);
   border-top-color: rgba(0, 0, 0, 0.1); }
+  * {
+    -GtkTreeView-horizontal-separator: 4;
+    -GtkTreeView-grid-line-width: 1;
+    -GtkTreeView-grid-line-pattern: '';
+    -GtkTreeView-tree-line-width: 1;
+    -GtkTreeView-tree-line-pattern: '';
+    -GtkTreeView-expander-size: 16; }
   treeview.view acceleditor > label {
     background-color: #cc575d; }
   treeview.view:selected, treeview.view:selected:focus {
@@ -1440,16 +1424,21 @@ treeview.view {
   treeview.view.progressbar, treeview.view.progressbar:focus {
     color: #ffffff;
     border-radius: 3px;
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
     treeview.view.progressbar:selected, treeview.view.progressbar:selected:focus, treeview.view.progressbar:focus:selected, treeview.view.progressbar:focus:selected:focus {
       color: #cc575d;
       box-shadow: none;
-      background-image: linear-gradient(to bottom, #ffffff); }
-  treeview.view.trough, treeview.view.trough:selected, treeview.view.trough:selected:focus {
+      background-color: #ffffff; }
+  treeview.view.trough {
     color: #5c616c;
-    background-image: linear-gradient(to bottom, #cfd6e6);
+    background-color: #cfd6e6;
     border-radius: 3px;
     border-width: 0; }
+    treeview.view.trough:selected, treeview.view.trough:selected:focus {
+      color: #ffffff;
+      background-color: rgba(0, 0, 0, 0.2);
+      border-radius: 3px;
+      border-width: 0; }
   treeview.view header button {
     min-height: 0;
     min-width: 0;
@@ -1839,7 +1828,7 @@ scrollbar {
     min-height: 40px; }
 
 switch {
-  font: 1;
+  font-size: 1px;
   min-width: 52px;
   min-height: 24px;
   background-size: 52px 24px;
@@ -2340,9 +2329,11 @@ frame > border,
   padding: 0;
   border-radius: 0;
   border: 1px solid #dcdfe3; }
-  frame > border.flat,
-  .frame.flat {
-    border-style: none; }
+
+frame.flat > border,
+frame > border.flat,
+.frame.flat {
+  border-style: none; }
 
 scrolledwindow viewport.frame {
   border-style: none; }
@@ -2474,19 +2465,16 @@ row.activatable:selected.has-open-popup, row.activatable:selected:hover {
     border: none; }
   .app-notification button {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: rgba(102, 109, 132, 0.35); }
     .app-notification button.flat, .app-notification button.sidebar-button {
       border-color: rgba(204, 87, 93, 0); }
     .app-notification button:hover {
       color: #BAC3CF;
-      outline-color: rgba(186, 195, 207, 0.3);
       border-color: rgba(26, 28, 34, 0.35);
       background-color: rgba(119, 127, 151, 0.45); }
     .app-notification button:active, .app-notification button:checked {
       color: #ffffff;
-      outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(26, 28, 34, 0.35);
       background-color: #cc575d;
       background-clip: padding-box; }
@@ -2512,24 +2500,16 @@ calendar {
   border-radius: 3px;
   padding: 2px; }
   calendar:selected {
-    background-color: #cc575d;
-    color: #ffffff;
     border-radius: 1.5px; }
   calendar.header {
     color: #5c616c;
-    border: none;
-    border-radius: 0; }
-  calendar.button, calendar.button:focus {
-    color: rgba(92, 97, 108, 0.45);
-    border-color: transparent;
-    background-color: transparent;
-    background-image: none; }
-    calendar.button:hover, calendar.button:focus:hover {
+    border: none; }
+  calendar.button {
+    color: rgba(92, 97, 108, 0.45); }
+    calendar.button:hover {
       color: #5c616c; }
-    calendar.button:disabled, calendar.button:focus:disabled {
-      color: rgba(92, 97, 108, 0.55);
-      background-color: transparent;
-      background-image: none; }
+    calendar.button:disabled {
+      color: rgba(92, 97, 108, 0.55); }
   calendar:indeterminate {
     color: alpha(currentColor,0.55); }
   calendar.highlight {
@@ -2630,7 +2610,7 @@ placessidebar row {
   placessidebar row.sidebar-placeholder-row {
     padding: 0 8px;
     min-height: 2px;
-    background-image: linear-gradient(to top, #F08437);
+    background-image: linear-gradient(to bottom, #F08437, #F08437);
     background-clip: content-box; }
   placessidebar row.sidebar-new-bookmark-row {
     color: #cc575d; }
@@ -2660,15 +2640,15 @@ paned > separator {
   -gtk-icon-source: none;
   border-style: none;
   background-color: transparent;
-  background-image: linear-gradient(to top, #dcdfe3);
+  background-image: linear-gradient(to bottom, #dcdfe3, #dcdfe3);
   background-size: 1px 1px; }
   paned > separator:selected {
-    background-image: linear-gradient(to top, #cc575d); }
+    background-image: linear-gradient(to bottom, #cc575d, #cc575d); }
   paned > separator.wide {
     min-width: 5px;
     min-height: 5px;
     background-color: #F5F6F7;
-    background-image: linear-gradient(to top, #dcdfe3), linear-gradient(to top, #dcdfe3);
+    background-image: linear-gradient(to bottom, #dcdfe3, #dcdfe3), linear-gradient(to bottom, #dcdfe3, #dcdfe3);
     background-size: 1px 1px, 1px 1px; }
 
 paned.horizontal > separator {
@@ -2700,107 +2680,44 @@ paned.vertical > separator {
 
 infobar {
   border-style: none; }
+  infobar.info, infobar.question, infobar.warning, infobar.error {
+    background-color: #cc575d;
+    color: #ffffff;
+    caret-color: currentColor; }
+    infobar.info selection, infobar.question selection, infobar.warning selection, infobar.error selection {
+      color: #cc575d;
+      background-color: #ffffff; }
 
-.info,
-.question,
-.warning,
-.error {
-  background-color: #cc575d;
-  color: #ffffff; }
-  .info label:selected:focus, .info label:selected:hover, .info label:selected,
-  .question label:selected:focus,
-  .question label:selected:hover,
-  .question label:selected,
-  .warning label:selected:focus,
-  .warning label:selected:hover,
-  .warning label:selected,
-  .error label:selected:focus,
-  .error label:selected:hover,
-  .error label:selected {
-    color: #cc575d;
-    background-color: #ffffff; }
-
-.selection-mode.primary-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, .info button,
-.question button,
-.warning button,
-.error button, .nautilus-window .floating-bar button {
+.selection-mode.primary-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, infobar.info button, infobar.question button, infobar.warning button, infobar.error button, .nautilus-window .floating-bar button {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.5); }
 
-row:selected button.flat, row:selected button.sidebar-button, .info button.flat, .info button.sidebar-button,
-.question button.flat,
-.question button.sidebar-button,
-.warning button.flat,
-.warning button.sidebar-button,
-.error button.flat,
-.error button.sidebar-button, .nautilus-window .floating-bar button.flat, .nautilus-window .floating-bar button.sidebar-button {
+row:selected button.flat, row:selected button.sidebar-button, infobar.info button.flat, infobar.info button.sidebar-button, infobar.question button.flat, infobar.question button.sidebar-button, infobar.warning button.flat, infobar.warning button.sidebar-button, infobar.error button.flat, infobar.error button.sidebar-button, .nautilus-window .floating-bar button.flat, .nautilus-window .floating-bar button.sidebar-button {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0); }
-  .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, row:selected button.flat:disabled, row:selected button.sidebar-button:disabled, .info button.flat:disabled, .info button.sidebar-button:disabled,
-  .question button.flat:disabled,
-  .question button.sidebar-button:disabled,
-  .warning button.flat:disabled,
-  .warning button.sidebar-button:disabled,
-  .error button.flat:disabled,
-  .error button.sidebar-button:disabled, .nautilus-window .floating-bar button.flat:disabled, .nautilus-window .floating-bar button.sidebar-button:disabled, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled label, row:selected button.sidebar-button:disabled label, .info button.flat:disabled label, .info button.sidebar-button:disabled label,
-  .question button.flat:disabled label,
-  .question button.sidebar-button:disabled label,
-  .warning button.flat:disabled label,
-  .warning button.sidebar-button:disabled label,
-  .error button.flat:disabled label,
-  .error button.sidebar-button:disabled label, .nautilus-window .floating-bar button.flat:disabled label, .nautilus-window .floating-bar button.sidebar-button:disabled label {
+  .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, row:selected button.flat:disabled, row:selected button.sidebar-button:disabled, infobar.info button.flat:disabled, infobar.info button.sidebar-button:disabled, infobar.question button.flat:disabled, infobar.question button.sidebar-button:disabled, infobar.warning button.flat:disabled, infobar.warning button.sidebar-button:disabled, infobar.error button.flat:disabled, infobar.error button.sidebar-button:disabled, .nautilus-window .floating-bar button.flat:disabled, .nautilus-window .floating-bar button.sidebar-button:disabled, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled label, row:selected button.sidebar-button:disabled label, infobar.info button.flat:disabled label, infobar.info button.sidebar-button:disabled label, infobar.question button.flat:disabled label, infobar.question button.sidebar-button:disabled label, infobar.warning button.flat:disabled label, infobar.warning button.sidebar-button:disabled label, infobar.error button.flat:disabled label, infobar.error button.sidebar-button:disabled label, .nautilus-window .floating-bar button.flat:disabled label, .nautilus-window .floating-bar button.sidebar-button:disabled label {
     color: rgba(255, 255, 255, 0.4); }
 
-row:selected button:hover, .info button:hover,
-.question button:hover,
-.warning button:hover,
-.error button:hover, .nautilus-window .floating-bar button:hover {
+row:selected button:hover, infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover, .nautilus-window .floating-bar button:hover {
   color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
   background-color: rgba(255, 255, 255, 0.2);
   border-color: rgba(255, 255, 255, 0.8); }
 
-.selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, .info button:active,
-.question button:active,
-.warning button:active,
-.error button:active, .nautilus-window .floating-bar button:active, .selection-mode.primary-toolbar button:hover:active, headerbar.selection-mode button:hover:active, .selection-mode.primary-toolbar button:hover:checked, headerbar.selection-mode button:hover:checked, row:selected button:active:hover, .info button:active:hover,
-.question button:active:hover,
-.warning button:active:hover,
-.error button:active:hover, .nautilus-window .floating-bar button:active:hover, row:selected button:checked, .info button:checked,
-.question button:checked,
-.warning button:checked,
-.error button:checked, .nautilus-window .floating-bar button:checked {
+.selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, .nautilus-window .floating-bar button:active, .selection-mode.primary-toolbar button:hover:active, headerbar.selection-mode button:hover:active, .selection-mode.primary-toolbar button:hover:checked, headerbar.selection-mode button:hover:checked, row:selected button:active:hover, infobar.info button:active:hover, infobar.question button:active:hover, infobar.warning button:active:hover, infobar.error button:active:hover, .nautilus-window .floating-bar button:active:hover, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked, .nautilus-window .floating-bar button:checked {
   color: #cc575d;
-  outline-color: rgba(204, 87, 93, 0.3);
   background-color: #ffffff;
   border-color: #ffffff; }
 
-row:selected button:disabled, .info button:disabled,
-.question button:disabled,
-.warning button:disabled,
-.error button:disabled, .nautilus-window .floating-bar button:disabled {
+row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, .nautilus-window .floating-bar button:disabled {
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.4); }
-  row:selected button:disabled, .info button:disabled,
-  .question button:disabled,
-  .warning button:disabled,
-  .error button:disabled, .nautilus-window .floating-bar button:disabled, row:selected button:disabled label, .info button:disabled label,
-  .question button:disabled label,
-  .warning button:disabled label,
-  .error button:disabled label, .nautilus-window .floating-bar button:disabled label {
+  row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, .nautilus-window .floating-bar button:disabled, row:selected button:disabled label, infobar.info button:disabled label, infobar.question button:disabled label, infobar.warning button:disabled label, infobar.error button:disabled label, .nautilus-window .floating-bar button:disabled label {
     color: rgba(255, 255, 255, 0.5); }
-  .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, row:selected button:disabled:active, .info button:disabled:active,
-  .question button:disabled:active,
-  .warning button:disabled:active,
-  .error button:disabled:active, .nautilus-window .floating-bar button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:checked, .info button:disabled:checked,
-  .question button:disabled:checked,
-  .warning button:disabled:checked,
-  .error button:disabled:checked, .nautilus-window .floating-bar button:disabled:checked {
+  .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, .nautilus-window .floating-bar button:disabled:active, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked, .nautilus-window .floating-bar button:disabled:checked {
     color: #cc575d;
     background-color: rgba(255, 255, 255, 0.5);
     border-color: rgba(255, 255, 255, 0.4); }
@@ -2875,12 +2792,10 @@ colorswatch#add-color-button {
   border-style: solid;
   border-width: 1px;
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: #fbfbfc; }
   colorswatch#add-color-button:hover {
     color: #5c616c;
-    outline-color: rgba(92, 97, 108, 0.3);
     border-color: #cfd6e6;
     background-color: white; }
   colorswatch#add-color-button overlay {
@@ -2904,7 +2819,6 @@ colorchooser .popover.osd {
 
 .scale-popup button:hover {
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: white; }
 
@@ -2913,13 +2827,14 @@ popover.background.touch-selection, .csd popover.background.touch-selection {
   font: initial; }
 
 .monospace {
-  font: Monospace; }
+  font-family: Monospace; }
 
 button.circular, button.nautilus-circular-button.image-button,
 button.circular-button {
   padding: 0;
-  min-width: 26px;
-  min-height: 26px;
+  min-width: 16px;
+  min-height: 24px;
+  padding: 2px 6px;
   border-radius: 50%;
   -gtk-outline-radius: 50%; }
   button.circular label, button.nautilus-circular-button.image-button label,
@@ -2997,14 +2912,12 @@ headerbar button.titlebutton,
   headerbar button.titlebutton:hover,
   .titlebar button.titlebutton:hover {
     color: rgba(82, 93, 118, 0.8);
-    outline-color: rgba(82, 93, 118, 0.1);
     border-color: rgba(82, 93, 118, 0.1);
     background-color: rgba(251, 251, 252, 0.9); }
   headerbar button.titlebutton:active, headerbar button.titlebutton:checked,
   .titlebar button.titlebutton:active,
   .titlebar button.titlebutton:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d; }
   headerbar button.titlebutton.close, headerbar button.titlebutton.maximize, headerbar button.titlebutton.minimize,
@@ -3066,7 +2979,7 @@ textview text selection, flowbox flowboxchild:selected, entry selection:focus, e
 modelbutton.flat:active,
 modelbutton.flat:active arrow,
 modelbutton.flat:selected,
-modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
+modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, calendar:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
 .nautilus-window placessidebar.sidebar row.sidebar-row.has-open-popup:selected,
 .nautilus-window placessidebar.sidebar row.sidebar-row:selected,
 .nautilus-window placessidebar.sidebar row.sidebar-row:selected:hover,
@@ -3080,20 +2993,19 @@ modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:
   modelbutton.flat:active,
   modelbutton.flat:active arrow,
   modelbutton.flat:selected,
-  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
+  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, calendar:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, filechooser placessidebar.sidebar row.sidebar-row.has-open-popup:selected, filechooser placessidebar.sidebar row.sidebar-row:selected, filechooser placessidebar.sidebar row.sidebar-row:selected:hover, filechooser placessidebar.sidebar row.sidebar-row:active:hover,
   .nautilus-window placessidebar.sidebar row.sidebar-row.has-open-popup:selected,
   .nautilus-window placessidebar.sidebar row.sidebar-row:selected,
   .nautilus-window placessidebar.sidebar row.sidebar-row:selected:hover,
   .nautilus-window placessidebar.sidebar row.sidebar-row:active:hover {
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3); }
+    color: #ffffff; }
     row:selected label:disabled, label:disabled:selected, .view:disabled:selected, iconview:disabled:selected, iconview:disabled:selected:focus, .view text:disabled:selected, iconview text:disabled:selected,
     textview text:disabled:selected, iconview text selection:disabled:focus, .view text selection:disabled, iconview text selection:disabled,
     textview text selection:disabled, flowbox flowboxchild:disabled:selected, label:disabled selection, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
     modelbutton.flat:disabled:active,
     modelbutton.flat:active arrow:disabled,
     modelbutton.flat:disabled:selected,
-    modelbutton.flat:selected arrow:disabled, treeview.view:disabled:selected:focus, row:disabled:selected, .nemo-window .nemo-window-pane widget.entry:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:active:hover,
+    modelbutton.flat:selected arrow:disabled, treeview.view:disabled:selected:focus, row:disabled:selected, calendar:disabled:selected, .nemo-window .nemo-window-pane widget.entry:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:selected, filechooser placessidebar.sidebar row.sidebar-row:disabled:active:hover,
     .nautilus-window placessidebar.sidebar row.sidebar-row:disabled:selected,
     .nautilus-window placessidebar.sidebar row.sidebar-row:disabled:active:hover {
       color: #e6abae; }
@@ -3102,10 +3014,12 @@ modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:
 terminal-window notebook > header.top > tabs > tab:checked {
   box-shadow: inset 0 -1px #dcdfe3; }
 
-terminal-window notebook > header.top {
+terminal-window notebook > header.top,
+.mate-terminal notebook > header.top {
   padding-top: 3px;
   box-shadow: inset 0 1px #d4d5db, inset 0 -1px #dcdfe3; }
-  terminal-window notebook > header.top button {
+  terminal-window notebook > header.top button,
+  .mate-terminal notebook > header.top button {
     padding: 0;
     min-width: 24px;
     min-height: 24px; }
@@ -3114,7 +3028,7 @@ terminal-window notebook > header.top {
   border-radius: 2px; }
 
 .nautilus-desktop.nautilus-canvas-item, .nemo-desktop.nemo-canvas-item, .caja-desktop {
-  color: #ffffff;
+  color: white;
   text-shadow: 1px 1px rgba(0, 0, 0, 0.6); }
   .nautilus-desktop.nautilus-canvas-item:active, .nemo-desktop.nemo-canvas-item:active, .caja-desktop:active {
     color: #5c616c; }
@@ -3157,12 +3071,10 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
 @keyframes needs_attention_keyframes {
   0% {
     color: rgba(82, 93, 118, 0.8);
-    outline-color: rgba(82, 93, 118, 0.1);
     border-color: rgba(82, 93, 118, 0.1);
     background-color: rgba(251, 251, 252, 0.9); }
   100% {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d; } }
 
@@ -3172,6 +3084,17 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
 .nautilus-operations-button-needs-attention-multiple {
   animation: needs_attention_keyframes 3s ease-in-out;
   animation-iteration-count: 3; }
+
+.conflict-row.activatable, .conflict-row.activatable:active {
+  color: white;
+  background-color: #FC4138; }
+
+.conflict-row.activatable:hover {
+  background-color: #fd716a; }
+
+.conflict-row.activatable:selected {
+  color: #ffffff;
+  background-color: #cc575d; }
 
 .nemo-window .nemo-places-sidebar.frame {
   border-width: 0; }
@@ -3184,12 +3107,10 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
   border-radius: 3px;
   color: #5c616c;
   border-color: #cc575d;
-  background-color: #ffffff;
-  background-image: linear-gradient(to bottom, #ffffff); }
+  background-color: #ffffff; }
 
 .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button {
   color: rgba(82, 93, 118, 0.8);
-  outline-color: rgba(82, 93, 118, 0.1);
   border-color: rgba(82, 93, 118, 0.1);
   background-color: rgba(251, 251, 252, 0.9); }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:not(:last-child):not(:only-child) {
@@ -3198,7 +3119,6 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
     background-color: rgba(255, 255, 255, 0.9); }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:active, .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d; }
   .nemo-window .primary-toolbar widget.raised.linked:not(.vertical):not(.path-bar) > button:disabled {
@@ -3292,6 +3212,27 @@ popover.background label.nautilus-canvas-item.separator, headerbar .nautilus-can
   margin: 2px;
   padding: 2px; }
 
+.gedit-map-frame border {
+  border-color: rgba(0, 0, 0, 0.3);
+  border-width: 0; }
+  .gedit-map-frame border:dir(ltr) {
+    border-left-width: 1px; }
+  .gedit-map-frame border:dir(rtl) {
+    border-right-width: 1px; }
+
+.pluma-window statusbar frame > border {
+  border: none; }
+
+.pluma-window notebook > stack scrolledwindow {
+  border-width: 0 0 1px 0; }
+
+#pluma-status-combo-button {
+  min-height: 0;
+  padding: 0;
+  border-top: none;
+  border-bottom: none;
+  border-radius: 0; }
+
 .gb-search-entry-occurrences-tag {
   background: none; }
 
@@ -3320,6 +3261,8 @@ pillbox {
   color: #ffffff;
   background-color: #cc575d;
   border-radius: 3px; }
+  pillbox:disabled label {
+    color: rgba(255, 255, 255, 0.5); }
 
 docktabstrip {
   padding: 0 6px;
@@ -3352,6 +3295,62 @@ dockoverlayedge {
   dockoverlayedge.left-edge tab:checked,
   dockoverlayedge.right-edge tab:checked {
     border-width: 1px 0; }
+
+popover.messagepopover.background {
+  padding: 0; }
+
+popover.messagepopover .popover-content-area {
+  margin: 16px; }
+
+popover.messagepopover .popover-action-area {
+  margin: 8px; }
+  popover.messagepopover .popover-action-area button:not(:first-child):not(:last-child) {
+    margin: 0 4px; }
+
+popover.popover-selector {
+  padding: 0; }
+  popover.popover-selector list row {
+    padding: 5px 0; }
+  popover.popover-selector list row image {
+    margin-left: 3px;
+    margin-right: 10px; }
+
+entry.search.preferences-search {
+  border: none;
+  border-right: 1px solid #dcdfe3;
+  border-bottom: 1px solid #dcdfe3;
+  border-radius: 0; }
+
+preferences stacksidebar.sidebar list {
+  background-image: linear-gradient(to bottom, #ffffff, #ffffff); }
+
+preferences stacksidebar.sidebar list separator {
+  background-color: transparent; }
+
+devhelppanel entry:focus,
+symboltreepanel entry:focus {
+  border-color: #dcdfe3; }
+
+button.run-arrow-button {
+  min-width: 12px; }
+
+omnibar.linked > entry:not(:only-child) {
+  border-style: solid;
+  border-radius: 3px;
+  margin-left: 1px;
+  margin-right: 1px; }
+
+gstyleslidein #scale_box button.toggle:checked,
+gstyleslidein #strings_controls button.toggle:checked,
+gstyleslidein #palette_controls button.toggle:checked,
+gstyleslidein #components_controls button.toggle:checked {
+  color: #5c616c; }
+
+configurationview entry.flat {
+  background: none; }
+
+configurationview list {
+  border-width: 0; }
 
 .documents-scrolledwin.frame {
   border-width: 0; }
@@ -3400,46 +3399,119 @@ button.documents-favorite:active:hover {
   opacity: 0.0;
   transition: opacity 0.2s ease-out; }
 
+.tweak-categories,
+.tweak-category:not(:selected):not(:hover) {
+  background-image: linear-gradient(to bottom, #ffffff, #ffffff); }
+
 .tr-workarea undershoot,
 .tr-workarea overshoot {
   border-color: transparent; }
 
-.gnome-panel-menu-bar, .gnome-panel-menu-bar menubar,
-.mate-panel-menu-bar,
-.mate-panel-menu-bar menubar {
-  background-color: rgba(43, 46, 55, 0.95); }
+.atril-window .primary-toolbar toolbar, .atril-window .primary-toolbar .inline-toolbar {
+  background: none; }
 
-.gnome-panel-menu-bar menubar,
-.gnome-panel-menu-bar #PanelApplet label,
-.gnome-panel-menu-bar #PanelApplet image,
+#gf-bubble, #gf-bubble.solid,
+#gf-osd-window,
+#gf-osd-window.solid,
+#gf-input-source-popup,
+#gf-input-source-popup.solid,
+#gf-candidate-popup,
+#gf-candidate-popup.solid {
+  color: #cfd5de;
+  background-color: rgba(53, 57, 69, 0.95);
+  border: 1px solid rgba(35, 38, 46, 0.95);
+  border-radius: 2px; }
+
+#gf-bubble levelbar block.low, #gf-bubble levelbar block.high, #gf-bubble levelbar block.full,
+#gf-osd-window levelbar block.low,
+#gf-osd-window levelbar block.high,
+#gf-osd-window levelbar block.full,
+#gf-input-source-popup levelbar block.low,
+#gf-input-source-popup levelbar block.high,
+#gf-input-source-popup levelbar block.full,
+#gf-candidate-popup levelbar block.low,
+#gf-candidate-popup levelbar block.high,
+#gf-candidate-popup levelbar block.full {
+  background-color: #cc575d;
+  border-color: #cc575d; }
+
+#gf-bubble levelbar block.empty,
+#gf-osd-window levelbar block.empty,
+#gf-input-source-popup levelbar block.empty,
+#gf-candidate-popup levelbar block.empty {
+  background-color: rgba(42, 45, 55, 0.95); }
+
+#gf-bubble levelbar trough,
+#gf-osd-window levelbar trough,
+#gf-input-source-popup levelbar trough,
+#gf-candidate-popup levelbar trough {
+  background: none; }
+
+#gf-input-source {
+  min-height: 32px;
+  min-width: 40px; }
+  #gf-input-source:selected {
+    color: #ffffff;
+    background-color: #cc575d;
+    border-radius: 2px; }
+
+gf-candidate-box label {
+  padding: 3px; }
+
+gf-candidate-box:hover, gf-candidate-box:selected {
+  color: #ffffff;
+  background-color: #cc575d;
+  border-radius: 2px; }
+
+MsdOsdWindow.background.osd {
+  border-radius: 2px;
+  border: 1px solid rgba(35, 38, 46, 0.95); }
+  MsdOsdWindow.background.osd .progressbar {
+    background-color: #cc575d;
+    border: none;
+    border-color: red;
+    border-radius: 5px; }
+  MsdOsdWindow.background.osd .trough {
+    background-color: rgba(42, 45, 55, 0.95);
+    border: none;
+    border-radius: 5px; }
+
+.mate-panel-menu-bar, .mate-panel-menu-bar menubar,
+panel-toplevel.background,
+panel-toplevel.background menubar {
+  background-color: #2b2e37; }
+
 .mate-panel-menu-bar menubar,
 .mate-panel-menu-bar #PanelApplet label,
-.mate-panel-menu-bar #PanelApplet image {
+.mate-panel-menu-bar #PanelApplet image,
+panel-toplevel.background menubar,
+panel-toplevel.background #PanelApplet label,
+panel-toplevel.background #PanelApplet image {
   color: #BAC3CF; }
 
-.gnome-panel-menu-bar button label, .gnome-panel-menu-bar button image,
-.gnome-panel-menu-bar #tasklist-button label,
-.gnome-panel-menu-bar #tasklist-button image,
-.mate-panel-menu-bar button label,
-.mate-panel-menu-bar button image,
+.mate-panel-menu-bar button label, .mate-panel-menu-bar button image,
 .mate-panel-menu-bar #tasklist-button label,
-.mate-panel-menu-bar #tasklist-button image {
+.mate-panel-menu-bar #tasklist-button image,
+panel-toplevel.background button label,
+panel-toplevel.background button image,
+panel-toplevel.background #tasklist-button label,
+panel-toplevel.background #tasklist-button image {
   color: inherit; }
 
-.gnome-panel-menu-bar .wnck-pager,
-.mate-panel-menu-bar .wnck-pager {
+.mate-panel-menu-bar .wnck-pager,
+panel-toplevel.background .wnck-pager {
   color: #5d6268;
   background-color: rgba(20, 22, 27, 0.95); }
-  .gnome-panel-menu-bar .wnck-pager:hover,
-  .mate-panel-menu-bar .wnck-pager:hover {
+  .mate-panel-menu-bar .wnck-pager:hover,
+  panel-toplevel.background .wnck-pager:hover {
     background-color: rgba(54, 58, 70, 0.95); }
-  .gnome-panel-menu-bar .wnck-pager:selected,
-  .mate-panel-menu-bar .wnck-pager:selected {
+  .mate-panel-menu-bar .wnck-pager:selected,
+  panel-toplevel.background .wnck-pager:selected {
     color: #e4a5a8;
     background-color: #cc575d; }
 
-.gnome-panel-menu-bar na-tray-applet,
-.mate-panel-menu-bar na-tray-applet {
+.mate-panel-menu-bar na-tray-applet,
+panel-toplevel.background na-tray-applet {
   -NaTrayApplet-icon-padding: 0;
   -NaTrayApplet-icon-size: 16px; }
 
@@ -3457,26 +3529,32 @@ button.documents-favorite:active:hover {
     color: #d8dde4;
     background-color: rgba(0, 0, 0, 0.17); }
   #tasklist-button:checked {
-    color: #ffffff;
+    color: white;
     background-color: rgba(0, 0, 0, 0.25);
     box-shadow: inset 0 -2px #cc575d; }
 
-.gnome-panel-menu-bar button:not(#tasklist-button),
-.mate-panel-menu-bar button:not(#tasklist-button), .xfce4-panel.panel button.flat, .xfce4-panel.panel button.sidebar-button {
+.mate-panel-menu-bar button:not(#tasklist-button),
+panel-toplevel.background button:not(#tasklist-button), .xfce4-panel.panel button.flat, .xfce4-panel.panel button.sidebar-button {
   color: #BAC3CF;
   border-radius: 0;
   border: none;
   background-color: rgba(43, 46, 55, 0); }
-  .gnome-panel-menu-bar button:hover:not(#tasklist-button),
-  .mate-panel-menu-bar button:hover:not(#tasklist-button), .xfce4-panel.panel button.flat:hover, .xfce4-panel.panel button.sidebar-button:hover {
+  .mate-panel-menu-bar button:hover:not(#tasklist-button),
+  panel-toplevel.background button:hover:not(#tasklist-button), .xfce4-panel.panel button.flat:hover, .xfce4-panel.panel button.sidebar-button:hover {
     border: none;
     background-color: rgba(65, 70, 84, 0.95); }
-  .gnome-panel-menu-bar button:active:not(#tasklist-button),
-  .mate-panel-menu-bar button:active:not(#tasklist-button), .xfce4-panel.panel button.flat:active, .xfce4-panel.panel button.sidebar-button:active, .gnome-panel-menu-bar button:checked:not(#tasklist-button),
-  .mate-panel-menu-bar button:checked:not(#tasklist-button), .xfce4-panel.panel button.flat:checked, .xfce4-panel.panel button.sidebar-button:checked {
+  .mate-panel-menu-bar button:active:not(#tasklist-button),
+  panel-toplevel.background button:active:not(#tasklist-button), .xfce4-panel.panel button.flat:active, .xfce4-panel.panel button.sidebar-button:active, .mate-panel-menu-bar button:checked:not(#tasklist-button),
+  panel-toplevel.background button:checked:not(#tasklist-button), .xfce4-panel.panel button.flat:checked, .xfce4-panel.panel button.sidebar-button:checked {
     color: #ffffff;
     border: none;
     background-color: #cc575d; }
+    .mate-panel-menu-bar button:active:not(#tasklist-button) label,
+    panel-toplevel.background button:active:not(#tasklist-button) label, .xfce4-panel.panel button.flat:active label, .xfce4-panel.panel button.sidebar-button:active label, .mate-panel-menu-bar button:active:not(#tasklist-button) image,
+    panel-toplevel.background button:active:not(#tasklist-button) image, .xfce4-panel.panel button.flat:active image, .xfce4-panel.panel button.sidebar-button:active image, .mate-panel-menu-bar button:checked:not(#tasklist-button) label,
+    panel-toplevel.background button:checked:not(#tasklist-button) label, .xfce4-panel.panel button.flat:checked label, .xfce4-panel.panel button.sidebar-button:checked label, .mate-panel-menu-bar button:checked:not(#tasklist-button) image,
+    panel-toplevel.background button:checked:not(#tasklist-button) image, .xfce4-panel.panel button.flat:checked image, .xfce4-panel.panel button.sidebar-button:checked image {
+      color: inherit; }
 
 .nautilus-window .floating-bar {
   padding: 1px;
@@ -3498,17 +3576,17 @@ button.documents-favorite:active:hover {
   padding-right: 4px;
   color: rgba(82, 93, 118, 0.8);
   border-color: rgba(82, 93, 118, 0.1);
-  background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.9));
-  background-color: transparent; }
+  background-color: rgba(255, 255, 255, 0.9); }
   .marlin-pathbar.pathbar image, .marlin-pathbar.pathbar image:hover {
     color: inherit; }
   .marlin-pathbar.pathbar:focus {
     color: #ffffff;
     border-color: #cc575d;
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
   .marlin-pathbar.pathbar:disabled {
     color: rgba(82, 93, 118, 0.35);
-    background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.75)); }
+    border-color: rgba(82, 93, 118, 0.1);
+    background-color: rgba(255, 255, 255, 0.75); }
   .marlin-pathbar.pathbar:active, .marlin-pathbar.pathbar:checked {
     color: #cc575d; }
 
@@ -3516,7 +3594,7 @@ button.documents-favorite:active:hover {
   border: 1px solid rgba(0, 0, 0, 0.35);
   border-radius: 3px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  background-image: linear-gradient(to bottom, white);
+  background-image: linear-gradient(to bottom, white, white);
   background-color: transparent; }
   .gala-notification .title, .gala-notification .label {
     color: #5c616c; }
@@ -3583,24 +3661,25 @@ UnityDecoration {
   -UnityDecoration-title-indent: 10px;
   -UnityDecoration-title-fade: 35px;
   -UnityDecoration-title-alignment: 0.0; }
-  UnityDecoration.top {
+  UnityDecoration .top {
     border: 1px solid rgba(0, 0, 0, 0.1);
     border-bottom-width: 0;
     border-radius: 4px 4px 0 0;
     padding: 1px 6px 0 6px;
-    background-image: linear-gradient(to bottom, #e7e8eb);
+    background-image: linear-gradient(to bottom, #e7e8eb, #e7e8eb);
     color: rgba(82, 93, 118, 0.8);
     box-shadow: inset 0 1px rgba(239, 240, 242, 0.95); }
-    UnityDecoration.top:backdrop {
+    UnityDecoration .top:backdrop {
       border-bottom-width: 0;
       color: rgba(82, 93, 118, 0.5); }
-  UnityDecoration.left, UnityDecoration.right, UnityDecoration.bottom, UnityDecoration.left:backdrop, UnityDecoration.right:backdrop, UnityDecoration.bottom:backdrop {
+  UnityDecoration .left, UnityDecoration .right, UnityDecoration .bottom,
+  UnityDecoration .left:backdrop, UnityDecoration .right:backdrop, UnityDecoration .bottom:backdrop {
     background-color: transparent;
-    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.1)); }
+    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1)); }
 
 UnityPanelWidget,
 .unity-panel {
-  background-image: linear-gradient(to bottom, #2f343f);
+  background-image: linear-gradient(to bottom, #2f343f, #2f343f);
   color: #f6f7f9;
   box-shadow: none; }
   UnityPanelWidget:backdrop,
@@ -3611,7 +3690,7 @@ UnityPanelWidget,
 .unity-panel.menubar .menuitem *:hover {
   border-radius: 0;
   color: #ffffff;
-  background-image: linear-gradient(to bottom, #cc575d);
+  background-image: linear-gradient(to bottom, #cc575d, #cc575d);
   border-bottom: none; }
 
 .lightdm.menu {
@@ -3804,7 +3883,7 @@ GraniteWidgetsWelcome {
 
 GraniteWidgetsWelcome label {
   color: #a9acb2;
-  font: open sans 11;
+  font-size: 11px;
   text-shadow: none; }
 
 GraniteWidgetsWelcome .h1,
@@ -3824,7 +3903,7 @@ GraniteWidgetsPopOver {
   margin: 0; }
 
 .popover_bg {
-  background-image: linear-gradient(to bottom, #ffffff);
+  background-image: linear-gradient(to bottom, #ffffff, #ffffff);
   border: 1px solid rgba(0, 0, 0, 0.3); }
 
 GraniteWidgetsPopOver .sidebar.view, GraniteWidgetsPopOver iconview.sidebar,
@@ -3835,13 +3914,13 @@ GraniteWidgetsXsEntry entry {
   padding: 4px; }
 
 .h1 {
-  font: open sans 24px; }
+  font-size: 24px; }
 
 .h2 {
-  font: open sans light 18px; }
+  font-size: 18px; }
 
 .h3 {
-  font: open sans 11px; }
+  font-size: 11px; }
 
 .h4,
 .category-label {
@@ -3858,24 +3937,25 @@ GtkListBox .h4 {
 #panel_window {
   background-color: rgba(43, 46, 55, 0.95);
   color: #BAC3CF;
-  font: bold;
+  font-weight: bold;
   box-shadow: inset 0 -1px rgba(27, 29, 35, 0.95); }
-  #panel_window menubar,
-  #panel_window menubar > menuitem {
-    background-color: transparent;
-    color: #BAC3CF;
-    font: bold; }
+  #panel_window menubar {
+    padding-left: 5px; }
+    #panel_window menubar, #panel_window menubar > menuitem {
+      background-color: transparent;
+      color: #BAC3CF;
+      font-weight: bold; }
   #panel_window menubar menuitem:disabled {
     color: rgba(186, 195, 207, 0.5); }
     #panel_window menubar menuitem:disabled label {
       color: inherit; }
   #panel_window menubar menu > menuitem {
-    font: normal; }
+    font-weight: normal; }
 
 #login_window,
 #shutdown_dialog,
 #restart_dialog {
-  font: normal;
+  font-weight: normal;
   border-style: none;
   background-color: transparent;
   color: #5c616c; }
@@ -3890,17 +3970,14 @@ GtkListBox .h4 {
 
 #content_frame button {
   color: #5c616c;
-  outline-color: rgba(92, 97, 108, 0.3);
   border-color: #cfd6e6;
   background-color: #fbfbfc; }
   #content_frame button:hover {
     color: #5c616c;
-    outline-color: rgba(92, 97, 108, 0.3);
     border-color: #cfd6e6;
     background-color: white; }
   #content_frame button:active, #content_frame button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: #cc575d;
     background-color: #cc575d; }
   #content_frame button:disabled {
@@ -3922,17 +3999,14 @@ GtkListBox .h4 {
 
 #buttonbox_frame button {
   color: #BAC3CF;
-  outline-color: rgba(186, 195, 207, 0.3);
   border-color: rgba(26, 28, 34, 0.35);
   background-color: rgba(102, 109, 132, 0.35); }
   #buttonbox_frame button:hover {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: rgba(119, 127, 151, 0.45); }
   #buttonbox_frame button:active, #buttonbox_frame button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: #cc575d; }
   #buttonbox_frame button:disabled {
@@ -3942,9 +4016,9 @@ GtkListBox .h4 {
 
 #login_window #user_combobox {
   color: #5c616c;
-  font: 13px; }
+  font-size: 13px; }
   #login_window #user_combobox menu {
-    font: normal; }
+    font-weight: normal; }
 
 #user_image {
   padding: 3px;
@@ -3952,55 +4026,49 @@ GtkListBox .h4 {
 
 #shutdown_button.button {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
+  color: green;
   background-color: #F04A50;
   border-color: #F04A50; }
   #shutdown_button.button:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #f4797e;
     border-color: #f4797e; }
   #shutdown_button.button:active, #shutdown_button.button:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #ec1b22;
     border-color: #ec1b22; }
 
 #restart_button.button {
   background-clip: border-box;
-  color: #ffffff;
-  outline-color: rgba(255, 255, 255, 0.3);
-  background-color: #be3941;
-  border-color: #be3941; }
+  color: green;
+  background-color: #BE3941;
+  border-color: #BE3941; }
   #restart_button.button:hover {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #ce5c63;
     border-color: #ce5c63; }
   #restart_button.button:active, #restart_button.button:checked {
     background-clip: border-box;
-    color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
+    color: green;
     background-color: #972d34;
     border-color: #972d34; }
 
 #greeter_infobar {
   border-bottom-width: 0;
-  font: bold; }
+  font-weight: bold; }
 
 .nautilus-window paned > separator {
-  background-image: linear-gradient(to top, rgba(53, 57, 69, 0.95)); }
+  background-image: linear-gradient(to bottom, rgba(53, 57, 69, 0.95), rgba(53, 57, 69, 0.95)); }
   .nautilus-window paned > separator:dir(ltr) {
     margin-left: -1px; }
   .nautilus-window paned > separator:dir(rtl) {
     margin-right: -1px; }
 
 filechooser paned > separator {
-  background-image: linear-gradient(to top, rgba(53, 57, 69, 0.95)); }
+  background-image: linear-gradient(to bottom, rgba(53, 57, 69, 0.95), rgba(53, 57, 69, 0.95)); }
 
 filechooser.csd.background, filechooser placessidebar list,
 .nautilus-window.csd.background,
@@ -4038,13 +4106,11 @@ filechooser placessidebar.sidebar,
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:hover,
       .nautilus-window placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:hover {
         color: #BAC3CF;
-        outline-color: rgba(186, 195, 207, 0.3);
         border-color: rgba(26, 28, 34, 0.35);
         background-color: rgba(119, 127, 151, 0.45); }
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:active,
       .nautilus-window placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:active {
         color: #ffffff;
-        outline-color: rgba(255, 255, 255, 0.3);
         border-color: #cc575d;
         background-color: #cc575d; }
       filechooser placessidebar.sidebar row.sidebar-row:not(:selected) button.sidebar-button:not(:hover):not(:active) > image,
@@ -4120,6 +4186,12 @@ filechooser actionbar {
 .gedit-bottom-panel-paned {
   background-color: #ffffff; }
 
+.gedit-side-panel-paned > separator {
+  background-image: linear-gradient(to bottom, rgba(53, 57, 69, 0.95), rgba(53, 57, 69, 0.95)); }
+
+.gedit-bottom-panel-paned > separator {
+  background-image: linear-gradient(to bottom, #dcdfe3, #dcdfe3); }
+
 .gedit-document-panel {
   background-color: rgba(53, 57, 69, 0.95); }
   .maximized .gedit-document-panel {
@@ -4142,17 +4214,14 @@ filechooser actionbar {
 
 filechooser actionbar button {
   color: #BAC3CF;
-  outline-color: rgba(186, 195, 207, 0.3);
   border-color: rgba(26, 28, 34, 0.35);
   background-color: rgba(102, 109, 132, 0.35); }
   .caja-side-pane > box button:hover:not(:active), filechooser actionbar button:hover {
     color: #BAC3CF;
-    outline-color: rgba(186, 195, 207, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: rgba(119, 127, 151, 0.45); }
   filechooser actionbar button:active, filechooser actionbar button:checked {
     color: #ffffff;
-    outline-color: rgba(255, 255, 255, 0.3);
     border-color: rgba(26, 28, 34, 0.35);
     background-color: #cc575d; }
   filechooser actionbar button:disabled {
@@ -4163,17 +4232,16 @@ filechooser actionbar button {
 filechooser actionbar entry {
   color: #BAC3CF;
   border-color: rgba(26, 28, 34, 0.35);
-  background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.35));
-  background-color: transparent; }
+  background-color: rgba(102, 109, 132, 0.35); }
   filechooser actionbar entry image, filechooser actionbar entry image:hover {
     color: inherit; }
   filechooser actionbar entry:focus {
     color: #ffffff;
     border-color: rgba(26, 28, 34, 0.35);
-    background-image: linear-gradient(to bottom, #cc575d); }
+    background-color: #cc575d; }
   filechooser actionbar entry:disabled {
     color: rgba(186, 195, 207, 0.55);
-    background-image: linear-gradient(to bottom, rgba(102, 109, 132, 0.2)); }
+    background-color: rgba(102, 109, 132, 0.2); }
 
 filechooser placessidebar.sidebar scrollbar,
 .nautilus-window placessidebar.sidebar scrollbar, .nemo-window .sidebar scrollbar, .caja-side-pane scrollbar {

--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -7,9 +7,10 @@ terminal-window notebook {
 }
 
 //
-// GNOME Terminal
+// GNOME Terminal, MATE Terminal
 //
-terminal-window {
+terminal-window,
+.mate-terminal {
 
   notebook {
     > header.top {
@@ -35,7 +36,7 @@ terminal-window {
 }
 
 .nautilus-desktop.nautilus-canvas-item {
-  color: $selected_fg_color;
+  color: white;
   text-shadow: 1px 1px transparentize(black, 0.4);
 
   &:active { color: $fg_color; }
@@ -102,6 +103,21 @@ $disk_space_free: darken($bg_color, 3%);
 .nautilus-operations-button-needs-attention-multiple {
   animation: needs_attention_keyframes 3s ease-in-out;
   animation-iteration-count: 3;
+}
+
+// Batch renaming dialog
+.conflict-row.activatable {
+  &, &:active {
+    color: $error_fg_color;
+    background-color: $error_color;
+  }
+
+  &:hover { background-color: lighten($error_color, 10%); }
+
+  &:selected {
+    color: $selected_fg_color;
+    background-color: $selected_bg_color;
+  }
 }
 
 //
@@ -239,9 +255,38 @@ $disk_space_free: darken($bg_color, 3%);
   padding: 2px;
 }
 
+.gedit-map-frame {
+  border {
+    @if $variant=='light' { border-color: transparentize(black, 0.7); }
+    border-width: 0;
+
+    &:dir(ltr) { border-left-width: 1px; }
+    &:dir(rtl) { border-right-width: 1px; }
+  }
+}
+
+//
+// Pluma
+//
+
+.pluma-window statusbar frame > border { border: none; }
+
+.pluma-window notebook > stack scrolledwindow { border-width: 0 0 1px 0; }
+
+#pluma-status-combo-button {
+  min-height: 0;
+  padding: 0;
+
+  border-top: none;
+  border-bottom: none;
+  border-radius: 0;
+}
+
 //
 // Gnome Builder
 //
+// TODO: Merge this with the upstream stylesheet
+
 .gb-search-entry-occurrences-tag { background: none; }
 
 workbench.csd > stack.titlebar:not(headerbar) {
@@ -276,6 +321,8 @@ pillbox {
   color: $selected_fg_color;
   background-color: $selected_bg_color;
   border-radius: 3px;
+
+  &:disabled label { color: transparentize($selected_fg_color, 0.5) }
 }
 
 docktabstrip {
@@ -322,6 +369,63 @@ dockoverlayedge {
   }
 }
 
+popover.messagepopover {
+  &.background { padding: 0; }
+
+  .popover-content-area { margin: 16px; }
+  .popover-action-area {
+    margin: 8px;
+
+    button:not(:first-child):not(:last-child) { margin: 0 4px; }
+  }
+}
+
+popover.popover-selector {
+  padding: 0;
+
+  list {
+    row { padding: 5px 0; }
+    row image { margin-left: 3px; margin-right: 10px; }
+  }
+}
+
+entry.search.preferences-search {
+  border: none;
+  border-right: 1px solid $borders_color;
+  border-bottom: 1px solid $borders_color;
+  border-radius: 0;
+}
+
+preferences stacksidebar.sidebar {
+  list { background-image: _solid($base_color); }
+
+  list separator { background-color: transparent; }
+}
+
+devhelppanel entry:focus,
+symboltreepanel entry:focus {
+  border-color: $borders_color
+}
+
+button.run-arrow-button {
+  min-width: 12px;
+}
+
+omnibar.linked > entry:not(:only-child) { border-style: solid; border-radius: 3px; margin-left: 1px; margin-right: 1px; }
+
+gstyleslidein {
+  #scale_box,
+  #strings_controls,
+  #palette_controls,
+  #components_controls {
+    button.toggle:checked { color: $fg_color; }
+  }
+}
+
+configurationview {
+  entry.flat { background: none; }
+  list { border-width: 0; }
+}
 
 //
 // Epiphany
@@ -398,6 +502,14 @@ button.documents-favorite:active:hover {
 }
 
 //
+// Gnome Tweak Tool
+//
+.tweak-categories,
+.tweak-category:not(:selected):not(:hover) {
+  background-image: _solid($base_color);
+}
+
+//
 // Transmission
 //
 .tr-workarea undershoot,
@@ -406,12 +518,89 @@ button.documents-favorite:active:hover {
 }
 
 //
+// Atril (MATE pdf viewer)
+//
+.atril-window .primary-toolbar toolbar {
+  background: none;
+}
+
+//
+// Gnome Flashback
+//
+#gf-bubble,
+#gf-osd-window,
+#gf-input-source-popup,
+#gf-candidate-popup {
+  &, &.solid {
+    color: lighten($osd_fg_color, 7%);
+    background-color: $osd_bg_color;
+    border: 1px solid darken($osd_bg_color, 8%);
+    border-radius: 2px;
+  }
+
+  levelbar {
+    block {
+      &.low, &.high, &.full {
+        background-color: $selected_bg_color;
+        border-color: $selected_bg_color;
+      }
+      &.empty { background-color: darken($osd_bg_color, 5%); }
+    }
+    trough { background: none; }
+  }
+
+  // FIXME still needs button styling
+}
+
+#gf-input-source {
+  min-height: 32px;
+  min-width: 40px;
+
+  &:selected {
+    color: $selected_fg_color;
+    background-color: $selected_bg_color;
+    border-radius: 2px;
+  }
+}
+
+gf-candidate-box {
+  label { padding: 3px; }
+
+  &:hover,
+  &:selected {
+    color: $selected_fg_color;
+    background-color: $selected_bg_color;
+    border-radius: 2px;
+  }
+}
+
+//
+// Mate OSD Window
+//
+MsdOsdWindow.background.osd {
+  border-radius: 2px;
+  border: 1px solid darken($osd_bg_color, 8%);
+
+  .progressbar {
+    background-color: $selected_bg_color;
+    border: none;
+    border-color: red;
+    border-radius: 5px;
+  }
+  .trough {
+    background-color: darken($osd_bg_color, 5%);
+    border: none;
+    border-radius: 5px;
+  }
+}
+
+//
 // Mate/Gnome Flashback Panel
 //
-.gnome-panel-menu-bar,
-.mate-panel-menu-bar {
+.mate-panel-menu-bar,
+panel-toplevel.background {
 
-  &, menubar { background-color: $panel_bg; }
+  &, menubar { background-color: opacify($panel_bg, 1); }
 
   menubar,
   #PanelApplet label,
@@ -469,7 +658,7 @@ button.documents-favorite:active:hover {
   }
 
   &:checked {
-    color: $selected_fg_color;
+    color: white;
     background-color: transparentize(black, 0.75);
     box-shadow: inset 0 -2px $selected_bg_color;
   }
@@ -489,6 +678,8 @@ button.documents-favorite:active:hover {
     color: $selected_fg_color;
     border: none;
     background-color: $selected_bg_color;
+
+    label, image { color: inherit; }
   }
 }
 
@@ -562,7 +753,7 @@ button.documents-favorite:active:hover {
     border: 1px solid rgba(0, 0, 0, 0.35);
     border-radius: 3px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-    background-image: linear-gradient(to bottom, white);
+    background-image: _solid(white);
     background-color: transparent;
 
   .title, .label {

--- a/common/gtk-3.0/3.20/sass/_colors.scss
+++ b/common/gtk-3.0/3.20/sass/_colors.scss
@@ -18,11 +18,16 @@ $link_visited_color: if($variant == 'light', darken($selected_bg_color,20%),
                                      lighten($selected_bg_color,10%));
 
 $selection_mode_bg: if($transparency == 'true', transparentize($selected_bg_color, 0.05), $selected_bg_color);
+$selection_mode_fg: $selected_fg_color;
 $warning_color: #F27835;
 $error_color: #FC4138;
+$warning_fg_color: white;
+$error_fg_color: white;
 $success_color: #73d216;
 $destructive_color: #F04A50;
-$suggested_color: #be3941;
+$suggested_color: #BE3941;
+$destructive_fg_color: white;
+$suggested_fg_color: white;
 
 $drop_target_color: #F08437;
 

--- a/common/gtk-3.0/3.20/sass/_common.scss
+++ b/common/gtk-3.0/3.20/sass/_common.scss
@@ -15,9 +15,6 @@ $darker_asset_suffix: if($darker=='true', '-dark', $asset_suffix);
   -GtkScrolledWindow-scrollbar-spacing: 0;
 
   -GtkToolItemGroup-expander-size: 11;
-  -GtkTreeView-expander-size: 11;
-
-  -GtkTreeView-horizontal-separator: 4;
 
   -GtkWidget-text-handle-width: 20;
   -GtkWidget-text-handle-height: 20;
@@ -26,7 +23,7 @@ $darker_asset_suffix: if($darker=='true', '-dark', $asset_suffix);
   -GtkDialog-action-area-border: 0;
 
   // We use the outline properties to signal the focus properties
-  outline-color: transparentize($fg_color, 0.7);
+  outline-color: gtkalpha(currentColor, 0.3);
   outline-style: dashed;
   outline-offset: -3px;
   outline-width: 1px;
@@ -163,7 +160,6 @@ textview { // This will get overridden by .view, needed by gedit line numbers
   border: none;
   background-color: $osd_bg_color;
   background-clip: padding-box;
-  outline-color: transparentize($osd_fg_color, 0.7);
   box-shadow: none;
 }
 
@@ -232,24 +228,24 @@ entry {
   selection { &:focus, & { @extend %selected_items; }}
 
   // error and warning style
-  @each $e_type, $e_color in (warning, $warning_color),
-                             (error, $error_color),
-                              // entry.search-missing for Gnome-Builder
-                             (search-missing, $error_color) {
+  @each $e_type, $e_color, $e_fg_color in (warning, $warning_color, $warning_fg_color),
+                                          (error, $error_color, $error_fg_color),
+                                          // entry.search-missing for Gnome-Builder
+                                          (search-missing, $error_color, $error_fg_color) {
     &.#{$e_type} {
-      color: $selected_fg_color;
+      color: $e_fg_color;
       border-color: if($variant=='light', $e_color, $entry_border);
-      background-image: linear-gradient(to bottom, mix($e_color, $base_color, 60%));
+      background-color: mix($e_color, $base_color, 60%);
 
-      image { color: $selected_fg_color; }
+      image { color: $e_fg_color; }
 
       &:focus {
-        color: $selected_fg_color;
-        background-image: linear-gradient(to bottom, $e_color);
+        color: $e_fg_color;
+        background-color: $e_color;
         box-shadow: none;
       }
       selection, selection:focus {
-        background-color: $selected_fg_color;
+        background-color: $e_fg_color;
         color: $e_color;
       }
     }
@@ -366,6 +362,8 @@ button {
 
     background-clip: if($variant=='light', border-box, padding-box);
     transition-duration: 50ms;
+
+    &:not(:disabled) label:disabled { color: inherit; opacity: 0.6; }
   }
 
   //Webkitgtk workaround start
@@ -425,7 +423,6 @@ button {
   // big standalone buttons like in Documents pager
   &.osd {
     color: $osd_fg_color;
-    outline-color: transparentize($osd_fg_color, 0.7);
     background-color: $osd_bg_color;
     border-color: darken($osd_bg_color, 8%);
 
@@ -466,21 +463,20 @@ button {
   .osd .linked:not(.vertical):not(.path-bar) > &:hover:not(:checked):not(:active) + &:not(:checked):not(:active) { box-shadow: none; }
 
   // Suggested and Destructive Action buttons
-  @each $b_type, $b_color in (suggested-action, $suggested_color),
-                             (destructive-action, $destructive_color) {
+  @each $b_type, $b_color, $b_fg in (suggested-action, $suggested_color, $suggested_fg_color),
+                                    (destructive-action, $destructive_color, $destructive_fg_color) {
     &.#{$b_type} {
-      @include button(suggested_destructive, $b_color);
+      @include button(suggested_destructive, $b_color, $b_fg);
 
       &.flat {
         @include button(undecorated);
         color: $b_color;
-        outline-color: transparentize($b_color, 0.7);
       }
       &:hover {
-        @include button(suggested_destructive, lighten($b_color, 10%));
+        @include button(suggested_destructive, lighten($b_color, 10%), $b_fg);
       }
       &:active, &:checked {
-        @include button(suggested_destructive, darken($b_color, 10%));
+        @include button(suggested_destructive, darken($b_color, 10%), $b_fg);
       }
       &.flat:disabled {
         @include button(undecorated);
@@ -545,6 +541,10 @@ button {
       @else { background-position: left 3px, left 2px; }
     }
   }
+
+  // hide separators
+  &.font,
+  &.file { separator { background-color: transparent; }}
 
   //inline-toolbar buttons
   .inline-toolbar &, .inline-toolbar &:backdrop {
@@ -628,29 +628,40 @@ toolbar.inline-toolbar toolbutton {
     > #{$_uncolored_button}:hover:not(:only-child),
     > #{$_uncolored_button}:hover + #{$_uncolored_button} { box-shadow: inset if($vert=='false', 1px 0, 0 1px) $b_border; }
 
-    > #{$_uncolored_button}:first-child:hover,
+    > #{$_uncolored_button}:disabled:not(:only-child),
+    > #{$_uncolored_button}:disabled + #{$_uncolored_button}:not(:hover) { box-shadow: inset if($vert=='false', 1px 0, 0 1px) transparentize($b_border, 0.5); }
+
     > button:active + #{$_uncolored_button}:hover,
     > button:checked + #{$_uncolored_button}:hover,
     > button.suggested-action + #{$_uncolored_button}:hover,
     > button.destructive-action + #{$_uncolored_button}:hover,
-    > entry + #{$_uncolored_button}:hover:not(:only-child) { box-shadow: none; }
+    > entry + #{$_uncolored_button}:hover:not(:only-child),
+
+    > #{$_uncolored_button}:first-child:disabled,
+    > #{$_uncolored_button}:disabled + #{$_uncolored_button}:disabled,
+    > #{$_uncolored_button}:first-child:hover,
+    > button:active + #{$_uncolored_button}:disabled,
+    > button:checked + #{$_uncolored_button}:disabled,
+    > button.suggested-action + #{$_uncolored_button}:disabled,
+    > button.destructive-action + #{$_uncolored_button}:disabled,
+    > entry + #{$_uncolored_button}:disabled:not(:only-child), { box-shadow: none; }
   }
 }
 
 // special case, because path-bars are bugged
 @mixin pathbar_linking_rules($sep_color:if($variant=='light', transparentize($button_border, 0.6), transparentize($button_border, 0.5))) {
 
-    > button + button { border-left-style: none; }
+  > button + button { border-left-style: none; }
 
-    > button:hover:not(:checked):not(:active):not(:only-child) {
+  > button:hover:not(:checked):not(:active):not(:only-child) {
 
-      &:hover {
-        box-shadow: inset  1px 0 $sep_color,
-                    inset -1px 0 $sep_color;
-      }
-      &:first-child:hover { box-shadow: inset -1px 0 $sep_color; }
-      &:last-child:hover { box-shadow: inset 1px 0 $sep_color; }
+    &:hover {
+      box-shadow: inset  1px 0 $sep_color,
+                  inset -1px 0 $sep_color;
     }
+    &:first-child:hover { box-shadow: inset -1px 0 $sep_color; }
+    &:last-child:hover { box-shadow: inset 1px 0 $sep_color; }
+  }
 }
 
 // Apply the rules defined above
@@ -798,6 +809,9 @@ spinbutton {
     > button:hover:not(:active),
     > button:hover + button { box-shadow: inset 1px 0 $button_border; }
 
+    > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover),
+    > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled { box-shadow: inset 1px 0 transparentize($button_border, 0.5); }
+
     > button:first-child:hover:not(:active),
     > button.up:dir(rtl):hover:not(:active),
     > entry + button:not(:active):hover { box-shadow: none; }
@@ -913,7 +927,7 @@ toolbar {
   }
 }
 
-.primary-toolbar {
+.primary-toolbar:not(.libreoffice-toolbar) {  // LO messes up the toolbar styling, so exclude LO toolbars
   color: $header_fg;
   background-color: opacify($header_bg, 1);
   box-shadow: none;
@@ -925,9 +939,9 @@ toolbar {
   //&:backdrop { background-color: opacify($header_bg_backdrop, 1); }
 
   separator { @extend %header_separator; }
-
-  @extend %header_widgets;
 }
+
+.primary-toolbar { @extend %header_widgets; }
 
 .inline-toolbar {
   @extend toolbar;
@@ -1000,14 +1014,14 @@ headerbar,
 
   // Selectionmode
   &.selection-mode {
-    color: $selected_fg_color;
+    color: $selection_mode_fg;
     background-color: $selection_mode_bg;
     border-color: darken($selection_mode_bg, 4%);
     box-shadow: none;
 
     &:backdrop {
       background-color: $selection_mode_bg;
-      color: transparentize($selected_fg_color, 0.4);
+      color: transparentize($selection_mode_fg, 0.4);
     }
 
     .subtitle:link { @extend *:link:selected;  }
@@ -1096,7 +1110,7 @@ headerbar {
     }
   }
 
-  > separator { background-image: linear-gradient(to top, $header_border); }
+  > separator { background-image: _solid($header_border); }
 
   @extend %titlebar;
 }
@@ -1142,19 +1156,19 @@ headerbar {
       background-color: transparent;
     }
 
-    @each $e_type, $e_color in (warning, $warning_color),
-                               (error, $error_color) {
+    @each $e_type, $e_color, $e_fg_color in (warning, $warning_color, $warning_fg_color),
+                                            (error, $error_color, $error_fg_color) {
       &.#{$e_type} {
-        color: $selected_fg_color;
+        color: $e_fg_color;
         border-color: if($darker=='false' and $variant=='light', $e_color, $header_entry_border);
-        background-image: linear-gradient(to bottom, mix($e_color, $header_bg, 60%));
+        background-color: mix($e_color, $header_bg, 60%);
 
         &:focus {
-          color: $selected_fg_color;
-          background-image: linear-gradient(to bottom, $e_color);
+          color: $e_fg_color;
+          background-color: $e_color;
         }
         selection, selection:focus {
-          background-color: $selected_fg_color;
+          background-color: $e_fg_color;
           color: $e_color;
         }
       }
@@ -1181,8 +1195,8 @@ headerbar {
 
     &, &.flat {
       @include button(undecorated);
-      color: $selected_fg_color;
-      background-color: transparentize($selected_fg_color, 1);
+      color: $selection_mode_fg;
+      background-color: transparentize($selection_mode_fg, 1);
     }
     &:hover { @extend %normal_selected_button; }
     &:active, &:checked { @extend %selected-button:active; }
@@ -1212,7 +1226,9 @@ headerbar {
     $_uncolored_button: 'button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action)';
 
     > #{$_uncolored_button}:hover:not(:only-child),
-    > #{$_uncolored_button}:hover + #{$_uncolored_button} { box-shadow: none; }
+    > #{$_uncolored_button}:hover + #{$_uncolored_button},
+    > #{$_uncolored_button}:disabled:not(:only-child),
+    > #{$_uncolored_button}:disabled + #{$_uncolored_button}:not(:hover) { box-shadow: none; }
   }
 
   // special case for path-bars and stack-switchers
@@ -1228,9 +1244,9 @@ headerbar {
 
       &, &:hover, &:active, &:checked, &:disabled { @extend %linked; }
     }
-
     @include pathbar_linking_rules($sep_color:$header_button_border);
   }
+
   // use linking rules for entries only
   .linked:not(.vertical):not(.path-bar) {
     @include linking_rules( $a:0.5,
@@ -1241,21 +1257,20 @@ headerbar {
   }
 
   // Headerbar Suggested and Destructive Action buttons
-  @each $b_type, $b_color in (suggested-action, $suggested_color),
-                             (destructive-action, $destructive_color) {
+  @each $b_type, $b_color, $b_fg in (suggested-action, $suggested_color, $suggested_fg_color),
+                                    (destructive-action, $destructive_color, $destructive_fg_color) {
     button.#{$b_type} {
-      @include button(suggested_destructive, $b_color);
+      @include button(suggested_destructive, $b_color, $b_fg);
 
       &.flat {
         @include button(undecorated);
         color: $b_color;
-        outline-color: transparentize($b_color, 0.7);
       }
       &:hover {
-        @include button(suggested_destructive, lighten($b_color, 10%));
+        @include button(suggested_destructive, lighten($b_color, 10%), $b_fg);
       }
       &:active, &:checked {
-        @include button(suggested_destructive, darken($b_color, 10%));
+        @include button(suggested_destructive, darken($b_color, 10%), $b_fg);
       }
       &.flat:disabled,
       &:disabled { @include button(header-insensitive); }
@@ -1284,6 +1299,9 @@ headerbar {
 
     > button:hover:not(:active),
     > button:hover + button { box-shadow: inset 1px 0 $header_button_border; }
+
+    > button:disabled + button:not(:disabled):not(:active):not(:checked):not(:hover),
+    > button:not(:disabled):not(:active):not(:checked):not(:hover) + button:disabled { box-shadow: inset 1px 0 $header_button_border; }
 
     > button:first-child:hover:not(:active),
     > entry + button:not(:active):hover { box-shadow: none; }
@@ -1409,11 +1427,14 @@ headerbar {
 // Tree Views
 //
 treeview.view {
-  -GtkTreeView-grid-line-width: 1;
-  -GtkTreeView-grid-line-pattern: '';
-  -GtkTreeView-tree-line-width: 1;
-  -GtkTreeView-tree-line-pattern: '';
-  -GtkTreeView-expander-size: 16;
+  @at-root * {
+    -GtkTreeView-horizontal-separator: 4;
+    -GtkTreeView-grid-line-width: 1;
+    -GtkTreeView-grid-line-pattern: '';
+    -GtkTreeView-tree-line-width: 1;
+    -GtkTreeView-tree-line-pattern: '';
+    -GtkTreeView-expander-size: 16;
+  }
 
   border-left-color: transparentize($fg_color, 0.85);   // this is actually the tree lines color,
   border-top-color: transparentize(black, 0.9);         // while this is the grid lines color, better then nothing
@@ -1474,19 +1495,26 @@ treeview.view {
   &.progressbar, &.progressbar:focus { // progress bar in treeviews
     color: $selected_fg_color;
     border-radius: 3px;
-    background-image: linear-gradient(to bottom, $selected_bg_color);
+    background-color: $selected_bg_color;
 
     &:selected, &:selected:focus {
       color: $selected_bg_color;
       box-shadow: none;
-      background-image: linear-gradient(to bottom, $selected_fg_color);
+      background-color: $selected_fg_color;
     }
   }
-  &.trough, &.trough:selected, &.trough:selected:focus { // progress bar trough in treeviews
+  &.trough { // progress bar trough in treeviews
     color: $fg_color;
-    background-image: linear-gradient(to bottom, $button_border);
+    background-color: $button_border;
     border-radius: 3px;
     border-width: 0;
+
+    &:selected, &:selected:focus {
+      color: $selected_fg_color;
+      background-color: transparentize(black, 0.8);
+      border-radius: 3px;
+      border-width: 0;
+    }
   }
 
   header {
@@ -1937,7 +1965,7 @@ scrollbar {
 // Switches
 //
 switch {
-  font: 1;
+  font-size: 1px;
 
   min-width: 52px;
   min-height: 24px;
@@ -2374,8 +2402,12 @@ frame > border,
   padding: 0;
   border-radius: 0;
   border: 1px solid $borders_color;
+}
 
-  &.flat { border-style: none; }
+frame.flat > border,
+frame > border.flat,
+.frame.flat {
+  border-style: none;
 }
 
 scrolledwindow {
@@ -2509,28 +2541,25 @@ calendar {
   padding: 2px;
 
   &:selected {
-    background-color: $selected_bg_color;
-    color: $selected_fg_color;
+    @extend %selected_items;
     border-radius: 1.5px;
   }
+
   &.header {
     color: $fg_color;
     border: none;
-    border-radius: 0;
   }
-  &.button, &.button:focus {
-    color: transparentize($fg_color,0.55);
-    @include button(undecorated);
 
-    &:hover {
-      color: $fg_color;
-    }
-    &:disabled {
-      color: $insensitive_fg_color;
-      background-color: transparent;
-      background-image: none;
-    }
+  &.button {
+    @extend %undecorated_button;
+
+    color: transparentize($fg_color,0.55);
+
+    &:hover { color: $fg_color; }
+
+    &:disabled { color: $insensitive_fg_color; }
   }
+
   &:indeterminate { color: gtkalpha(currentColor,0.55); }
   &.highlight { color: $fg_color; }
 }
@@ -2681,7 +2710,7 @@ placessidebar {
     &.sidebar-placeholder-row {
       padding: 0 8px;
       min-height: 2px;
-      background-image: linear-gradient(to top, $drop_target_color);
+      background-image: _solid($drop_target_color);
       background-clip: content-box;
     }
 
@@ -2731,16 +2760,16 @@ paned {
     -gtk-icon-source: none;
     border-style: none;
     background-color: transparent;
-    background-image: linear-gradient(to top, $borders_color);
+    background-image: _solid($borders_color);
     background-size: 1px 1px;
 
-    &:selected { background-image: linear-gradient(to top, $selected_bg_color); }
+    &:selected { background-image: _solid($selected_bg_color); }
 
     &.wide {
       min-width: 5px;
       min-height: 5px;
       background-color: $bg_color;
-      background-image: linear-gradient(to top, $borders_color), linear-gradient(to top, $borders_color);
+      background-image: _solid($borders_color), _solid($borders_color);
       background-size: 1px 1px, 1px 1px;
     }
   }
@@ -2784,27 +2813,27 @@ paned {
 //
 // GtkInfoBar
 //
-infobar { border-style: none; }
+infobar {
+  border-style: none;
 
-.info,
-.question,
-.warning,
-.error {
-  background-color: $selected_bg_color;
-  color: $selected_fg_color;
+  &.info,
+  &.question,
+  &.warning,
+  &.error {
+    background-color: $selected_bg_color;
+    color: $selected_fg_color;
+    caret-color: currentColor;
 
-  button { @extend %selected-button }
+    button { @extend %selected-button }
 
-  label:selected {
-    &:focus, &:hover, & {
+    selection {
       color: $selected_bg_color;
       background-color: $selected_fg_color;
     }
+
+    *:link { @extend %link_selected; }
   }
-
-  *:link { @extend %link_selected; }
 }
-
 
 //
 // Buttons on selected backgrounds
@@ -2813,7 +2842,6 @@ infobar { border-style: none; }
 
   @at-root %normal_selected_button, & {
     color: $selected_fg_color;
-    outline-color: transparentize($selected_fg_color, 0.7);
     background-color: transparentize($selected_fg_color, 1);
     border-color: transparentize($selected_fg_color, 0.5);
   }
@@ -2829,13 +2857,11 @@ infobar { border-style: none; }
   }
   &:hover {
     color: $selected_fg_color;
-    outline-color: transparentize($selected_fg_color, 0.7);
     background-color: transparentize($selected_fg_color, 0.8);
     border-color: transparentize($selected_fg_color, 0.2);
   }
   &:active, &:active:hover, &:checked {
     color: $selected_bg_color;
-    outline-color: transparentize($selected_bg_color, 0.7);
     background-color: $selected_fg_color;
     border-color: $selected_fg_color;
   }
@@ -2997,7 +3023,7 @@ colorchooser .popover.osd { border-radius: 3px; }
 
 // Decouple the font of context menus from their entry/textview
 .context-menu { font: initial; }
-.monospace { font: Monospace; }
+.monospace { font-family: Monospace; }
 
 //
 // Shortcuts Help
@@ -3005,8 +3031,9 @@ colorchooser .popover.osd { border-radius: 3px; }
 button.circular,
 button.circular-button {
   padding: 0;
-  min-width: 26px;
-  min-height: 26px;
+  min-width: 16px;
+  min-height: 24px;
+  padding: 2px 6px;
   border-radius: 50%;
   -gtk-outline-radius: 50%;
 
@@ -3151,7 +3178,6 @@ headerbar,
 
   @at-root %nobg_selected_items, & {
     color: $selected_fg_color;
-    outline-color: transparentize($selected_fg_color, 0.7);
 
     &:disabled { color: mix($selected_fg_color, $selected_bg_color, 50%); }
   }

--- a/common/gtk-3.0/3.20/sass/_drawing.scss
+++ b/common/gtk-3.0/3.20/sass/_drawing.scss
@@ -1,5 +1,10 @@
 // Drawing mixins
 
+// Solid color image
+@function _solid($c) {
+  @return linear-gradient(to bottom, $c, $c);
+}
+
 // Entries
 
 @mixin entry($t) {
@@ -16,7 +21,6 @@
     color: $text_color;
     border-color: $entry_border;
     background-color: $entry_bg;
-    background-image: linear-gradient(to bottom, $entry_bg);
   }
 
   @if $t==focus {
@@ -26,7 +30,6 @@
     color: $text_color;
     border-color: if($variant=='light', $selected_bg_color, $button_border);
     background-color: $entry_bg;
-    background-image: linear-gradient(to bottom, $entry_bg);
 
     @if $variant == 'dark' {
       box-shadow: inset 1px 0 $selected_bg_color,
@@ -43,7 +46,6 @@
     color: $insensitive_fg_color;
     border-color: transparentize($entry_border, 0.45);
     background-color: transparentize($entry_bg, 0.45);
-    background-image: linear-gradient(to bottom, transparentize($entry_bg, 0.45));
   }
 
   @if $t==header-normal {
@@ -53,8 +55,7 @@
 
     color: $header_fg;
     border-color: $header_entry_border;
-    background-image: linear-gradient(to bottom, $header_entry_bg);
-    background-color: transparent;
+    background-color: $header_entry_bg;
 
     image, image:hover { color: inherit; }
   }
@@ -65,7 +66,7 @@
   //
     color: $selected_fg_color;
     border-color: if($darker=='false' and $variant=='light', $selected_bg_color, transparent);
-    background-image: linear-gradient(to bottom, $selected_bg_color);
+    background-color: $selected_bg_color;
   }
 
   @if $t==header-insensitive {
@@ -73,7 +74,8 @@
   // insensitive header-bar entry
   //
     color: transparentize($header_fg, 0.45);
-    background-image: linear-gradient(to bottom, transparentize($header_entry_bg, 0.15));
+    border-color: $header_entry_border;
+    background-color: transparentize($header_entry_bg, 0.15);
   }
 
   @else if $t==osd {
@@ -82,8 +84,7 @@
   //
     color: $osd_fg_color;
     border-color: $osd_entry_border;
-    background-image: linear-gradient(to bottom, $osd_entry_bg);
-    background-color: transparent;
+    background-color: $osd_entry_bg;
 
     image, image:hover { color: inherit; }
   }
@@ -94,7 +95,7 @@
   //
     color: $selected_fg_color;
     border-color: $osd_entry_border;
-    background-image: linear-gradient(to bottom, $selected_bg_color);
+    background-color: $selected_bg_color;
   }
 
   @else if $t==osd-insensitive {
@@ -102,25 +103,24 @@
   // insensitive osd entry
   //
     color: transparentize($osd_fg_color, 0.45);
-    background-image: linear-gradient(to bottom, transparentize($osd_entry_bg, 0.15));
+    background-color: transparentize($osd_entry_bg, 0.15);
   }
 }
 
 // Buttons
 
-@mixin button($t, $actionb_color:red) {
+@mixin button($t, $actionb_bg:red, $actionb_fg: green) {
 //
 // Button drawing function
 //
 // $t:    button type,
-// $actionb_color: used for destructive and suggested action buttons
+// $actionb_bg, $actionb_fg: used for destructive and suggested action buttons
 
   @if $t==normal {
   //
   // normal button
   //
     color: $fg_color;
-    outline-color: transparentize($fg_color, 0.7);
     border-color: $button_border;
     background-color: $button_bg;
   }
@@ -130,7 +130,6 @@
   // hovered button
   //
     color: $fg_color;
-    outline-color: transparentize($fg_color, 0.7);
     border-color: $button_border;
     background-color: lighten($button_bg, 5%);
   }
@@ -140,8 +139,6 @@
   // pushed button
   //
     color: $selected_fg_color;
-    outline-color: transparentize($selected_fg_color, 0.7);
-
     border-color: if($variant=='light', $selected_bg_color, $button_border);
     background-color: $selected_bg_color;
   }
@@ -173,7 +170,6 @@
   // normal header-bar button
   //
     color: $header_fg;
-    outline-color: transparentize($header_fg, 0.7);
     outline-offset: -3px;
     background-color: transparentize($header_bg, 1);
     border-color: transparentize($header_bg, 1);
@@ -184,7 +180,6 @@
   // hovered header-bar button
   //
     color: $header_fg;
-    outline-color: transparentize($header_fg, 0.7);
     border-color: $header_button_border;
     background-color: $header_button_bg;
   }
@@ -194,7 +189,6 @@
   // pushed header-bar button
   //
     color: $selected_fg_color;
-    outline-color: transparentize($selected_fg_color, 0.7);
     border-color: if($darker=='false' and $variant=='light', $selected_bg_color, transparent);
     background-color: $selected_bg_color;
   }
@@ -223,7 +217,6 @@
   // normal osd button
   //
     color: $osd_fg_color;
-    outline-color: transparentize($osd_fg_color, 0.7);
     border-color: $osd_button_border;
     background-color: $osd_button_bg;
   }
@@ -233,7 +226,6 @@
   // active osd button
   //
     color: $osd_fg_color;
-    outline-color: transparentize($osd_fg_color, 0.7);
     border-color: $osd_button_border;
     background-color: opacify(lighten($osd_button_bg, 7%), 0.1);
   }
@@ -243,7 +235,6 @@
   // active osd button
   //
     color: $selected_fg_color;
-    outline-color: transparentize($selected_fg_color, 0.7);
     border-color: $osd_button_border;
     background-color: $selected_bg_color;
   }
@@ -263,10 +254,9 @@
   //
     background-clip: border-box;
 
-    color: $selected_fg_color;
-    outline-color: transparentize($selected_fg_color, 0.7);
-    background-color: $actionb_color;
-    border-color: $actionb_color;
+    color: $actionb_fg;
+    background-color: $actionb_bg;
+    border-color: $actionb_bg;
   }
 
   @else if $t==undecorated {

--- a/common/gtk-3.0/3.20/sass/_granite.scss
+++ b/common/gtk-3.0/3.20/sass/_granite.scss
@@ -151,7 +151,7 @@ GraniteWidgetsWelcome {
 
 GraniteWidgetsWelcome label {
   color: mix($fg_color, $bg_color, 50%);
-  font: open sans 11;
+  font-size: 11px;
   text-shadow: none;
 }
 
@@ -182,7 +182,7 @@ GraniteWidgetsPopOver {
 }
 
 .popover_bg {
-  background-image: linear-gradient(to bottom, $base_color);
+  background-image: _solid($base_color);
   border: 1px solid transparentize(black, 0.7);
 }
 
@@ -199,9 +199,9 @@ GraniteWidgetsXsEntry entry { padding: 4px; }
 //
 // Text Styles
 //
-.h1 { font: open sans 24px; }
-.h2 { font: open sans light 18px; }
-.h3 { font: open sans 11px; }
+.h1 { font-size: 24px; }
+.h2 { font-size: 18px; }
+.h3 { font-size: 11px; }
 .h4,
 .category-label {
     color: mix($bg_color, $text_color, 30%);

--- a/common/gtk-3.0/3.20/sass/_lightdm.scss
+++ b/common/gtk-3.0/3.20/sass/_lightdm.scss
@@ -2,15 +2,18 @@
 #panel_window {
   background-color: $panel_bg;
   color: $panel_fg;
-  font: bold;
+  font-weight: bold;
   box-shadow: inset 0 -1px darken($panel_bg, 7%);
 
   // the menubars/menus of the panel, i.e. indicators
-  menubar,
-  menubar > menuitem {
-    background-color: transparent;
-    color: $panel_fg;
-    font: bold;
+  menubar {
+    padding-left: 5px;
+
+    &, > menuitem {
+      background-color: transparent;
+      color: $panel_fg;
+      font-weight: bold;
+    }
   }
 
   menubar menuitem:disabled {
@@ -18,14 +21,14 @@
 
     label { color: inherit; }
   }
-  menubar menu > menuitem { font: normal; }
+  menubar menu > menuitem { font-weight: normal; }
 }
 
 // the login window
 #login_window,
 #shutdown_dialog,
 #restart_dialog {
-  font: normal;
+  font-weight: normal;
   border-style: none;
   background-color: transparent;
   color: $fg_color;
@@ -72,9 +75,9 @@
 
 #login_window #user_combobox {
   color: $fg_color;
-  font: 13px;
+  font-size: 13px;
 
-  menu { font: normal; }
+  menu { font-weight: normal; }
 }
 
 // the user's avatar box
@@ -102,5 +105,5 @@
 // the warning, in case a wrong password is entered or something else goes wrong according to PAM
 #greeter_infobar {
   border-bottom-width: 0;
-  font: bold;
+  font-weight: bold;
 }

--- a/common/gtk-3.0/3.20/sass/_transparent_widgets.scss
+++ b/common/gtk-3.0/3.20/sass/_transparent_widgets.scss
@@ -3,7 +3,7 @@
 //.nemo-window,
 .nautilus-window {
   paned > separator {
-    background-image: linear-gradient(to top, $dark_sidebar_border);
+    background-image: _solid($dark_sidebar_border);
 
     @if $variant=='light' {
       &:dir(ltr) { margin-left: -1px; }
@@ -12,7 +12,7 @@
   }
 }
 
-filechooser paned > separator { background-image: linear-gradient(to top, $dark_sidebar_border); }
+filechooser paned > separator { background-image: _solid($dark_sidebar_border); }
 
 // Dark transparent sidebars
 filechooser,
@@ -144,6 +144,9 @@ filechooser {
 
 // Gedit
 .gedit-bottom-panel-paned { background-color: $base_color; }
+
+.gedit-side-panel-paned > separator { background-image: _solid($dark_sidebar_border); }
+.gedit-bottom-panel-paned > separator { background-image: _solid($borders_color); }
 
 .gedit-document-panel {
   background-color: $dark_sidebar_bg;

--- a/common/gtk-3.0/3.20/sass/_unity.scss
+++ b/common/gtk-3.0/3.20/sass/_unity.scss
@@ -17,34 +17,34 @@ UnityDecoration {
   -UnityDecoration-title-fade: 35px;
   -UnityDecoration-title-alignment: 0.0;
 
-  &.top {
+  .top {
     border: 1px solid if($darker=='true' or $variant == 'dark', darken($header_bg, 7%), transparentize(black, 0.9));
     border-bottom-width: 0;
     border-radius: 4px 4px 0 0;
     padding: 1px 6px 0 6px;
 
-    background-image: linear-gradient(to bottom, opacify($header_bg, 1));
+    background-image: _solid(opacify($header_bg, 1));
     color: $header_fg;                         // The foreground color will be used to paint the text
 
     box-shadow: inset 0  1px lighten($header_bg, 3%);
 
     &:backdrop {
       border-bottom-width: 0;
-      //background-image: linear-gradient(to bottom, opacify($header_bg_backdrop, 1));
+      //background-image: _solid(opacify($header_bg_backdrop, 1));
       color: transparentize($header_fg, 0.3);
     }
   }
-  &.left, &.right, &.bottom,
-  &.left:backdrop, &.right:backdrop, &.bottom:backdrop {
+  .left, .right, .bottom,
+  .left:backdrop, .right:backdrop, .bottom:backdrop {
     background-color: transparent;
-    background-image: linear-gradient(to bottom, if($darker=='true' or $variant == 'dark', darken($header_bg, 7%), transparentize(black, 0.9)));
+    background-image: _solid(if($darker=='true' or $variant == 'dark', darken($header_bg, 7%), transparentize(black, 0.9)));
   }
 }
 
 // Panel Style
 UnityPanelWidget,
 .unity-panel {
-  background-image: linear-gradient(to bottom, #2f343f);
+  background-image: _solid(#2f343f);
   color: lighten($panel_fg, 20%);
   box-shadow: none;
 
@@ -55,7 +55,7 @@ UnityPanelWidget,
 .unity-panel.menubar .menuitem *:hover {
   border-radius: 0;
   color: $selected_fg_color;
-  background-image: linear-gradient(to bottom, $selected_bg_color);
+  background-image: _solid($selected_bg_color);
   border-bottom: none;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3895 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "dev": true,
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-differ": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+      "dev": true
+    },
+    "array-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-slice": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+      "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
+      "dev": true
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "async-foreach": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
+      "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.0",
+        "pascalcase": "0.1.1"
+      }
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "beeper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+      "dev": true
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "dev": true,
+      "requires": {
+        "hoek": "4.2.0"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.0.tgz",
+      "integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.2",
+        "snapdragon": "0.8.1",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.1"
+      }
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
+      }
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
+      }
+    },
+    "clone": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+      "dev": true
+    },
+    "clone-stats": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
+      }
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+      "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "which": "1.3.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        }
+      }
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "dev": true,
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "dev": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
+      }
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "1.0.2"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "dateformat": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "requires": {
+        "clone": "1.0.3"
+      }
+    },
+    "define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "1.0.2"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
+    "deprecated": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+      "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
+      "dev": true
+    },
+    "detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "dev": true
+    },
+    "duplexer2": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.1.14"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "end-of-stream": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+      "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+      "dev": true,
+      "requires": {
+        "once": "1.3.3"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "1.0.1"
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "requires": {
+        "is-extendable": "0.1.1"
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fancy-log": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+      "dev": true,
+      "requires": {
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
+        "time-stamp": "1.1.0"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
+      }
+    },
+    "find-index": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+      "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
+      "dev": true
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "findup-sync": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+      "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+      "dev": true,
+      "requires": {
+        "detect-file": "1.0.0",
+        "is-glob": "3.1.0",
+        "micromatch": "3.1.5",
+        "resolve-dir": "1.0.1"
+      }
+    },
+    "fined": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
+      "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.3.0",
+        "parse-filepath": "1.0.2"
+      }
+    },
+    "first-chunk-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+      "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+      "dev": true
+    },
+    "flagged-respawn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
+      "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=",
+      "dev": true
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "for-own": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "0.2.2"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        }
+      }
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
+      }
+    },
+    "gaze": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+      "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
+      "dev": true,
+      "requires": {
+        "globule": "0.1.0"
+      }
+    },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "glob": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+      "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+      "dev": true,
+      "requires": {
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "2.0.10",
+        "once": "1.3.3"
+      }
+    },
+    "glob-stream": {
+      "version": "3.1.18",
+      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+      "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
+      "dev": true,
+      "requires": {
+        "glob": "4.5.3",
+        "glob2base": "0.0.12",
+        "minimatch": "2.0.10",
+        "ordered-read-streams": "0.1.0",
+        "through2": "0.6.5",
+        "unique-stream": "1.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
+    "glob-watcher": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+      "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+      "dev": true,
+      "requires": {
+        "gaze": "0.5.2"
+      }
+    },
+    "glob2base": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+      "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
+      "dev": true,
+      "requires": {
+        "find-index": "0.1.1"
+      }
+    },
+    "global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.1",
+        "resolve-dir": "1.0.1"
+      }
+    },
+    "global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.1",
+        "which": "1.3.0"
+      }
+    },
+    "globule": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+      "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
+      "dev": true,
+      "requires": {
+        "glob": "3.1.21",
+        "lodash": "1.0.2",
+        "minimatch": "0.2.14"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "3.1.21",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
+          }
+        },
+        "graceful-fs": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+          "dev": true
+        },
+        "inherits": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        }
+      }
+    },
+    "glogg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+      "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+      "dev": true,
+      "requires": {
+        "sparkles": "1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+      "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+      "dev": true,
+      "requires": {
+        "natives": "1.1.1"
+      }
+    },
+    "gulp": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+      "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
+      "dev": true,
+      "requires": {
+        "archy": "1.0.0",
+        "chalk": "1.1.3",
+        "deprecated": "0.0.1",
+        "gulp-util": "3.0.8",
+        "interpret": "1.1.0",
+        "liftoff": "2.5.0",
+        "minimist": "1.2.0",
+        "orchestrator": "0.3.8",
+        "pretty-hrtime": "1.0.3",
+        "semver": "4.3.6",
+        "tildify": "1.2.0",
+        "v8flags": "2.1.1",
+        "vinyl-fs": "0.3.14"
+      }
+    },
+    "gulp-rename": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
+      "integrity": "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc=",
+      "dev": true
+    },
+    "gulp-sass": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-2.2.0.tgz",
+      "integrity": "sha1-rH+zMRJEPuT9LfdGjtlmoUpyR28=",
+      "dev": true,
+      "requires": {
+        "gulp-util": "3.0.8",
+        "node-sass": "3.13.1",
+        "object-assign": "4.1.1",
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
+      }
+    },
+    "gulp-util": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+      "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+      "dev": true,
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.2",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
+        "replace-ext": "0.0.1",
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
+      }
+    },
+    "gulplog": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+      "dev": true,
+      "requires": {
+        "glogg": "1.0.1"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-gulplog": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+      "dev": true,
+      "requires": {
+        "sparkles": "1.0.0"
+      }
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "dev": true,
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.1.0"
+      }
+    },
+    "hoek": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
+      "dev": true
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "1.0.0"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
+    },
+    "in-publish": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.3.3",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
+    "is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "dev": true,
+      "requires": {
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.1"
+      }
+    },
+    "is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "6.0.2"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "6.0.2"
+      }
+    },
+    "is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "1.0.0",
+        "is-data-descriptor": "1.0.0",
+        "kind-of": "6.0.2"
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-glob": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-odd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
+      "integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0"
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dev": true,
+      "requires": {
+        "is-unc-path": "1.0.0"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dev": true,
+      "requires": {
+        "unc-path-regex": "0.1.2"
+      }
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
+      "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "js-base64": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
+      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
+      "dev": true
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
+    },
+    "lazy-cache": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+      "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+      "dev": true,
+      "requires": {
+        "set-getter": "0.1.0"
+      }
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
+    },
+    "liftoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
+      "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+      "dev": true,
+      "requires": {
+        "extend": "3.0.1",
+        "findup-sync": "2.0.0",
+        "fined": "1.1.0",
+        "flagged-respawn": "1.0.0",
+        "is-plain-object": "2.0.4",
+        "object.map": "1.0.1",
+        "rechoir": "0.6.2",
+        "resolve": "1.5.0"
+      }
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        }
+      }
+    },
+    "lodash": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+      "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
+      "dev": true
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basetostring": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+      "dev": true
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash._reescape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+      "dev": true
+    },
+    "lodash._reevaluate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+      "dev": true
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+      "dev": true
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "lodash.escape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+      "dev": true,
+      "requires": {
+        "lodash._root": "3.0.1"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+      "dev": true
+    },
+    "lodash.template": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "make-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.0.tgz",
+      "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "1.0.1"
+      }
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
+      }
+    },
+    "micromatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.5.tgz",
+      "integrity": "sha512-ykttrLPQrz1PUJcXjwsTUjGoPJ64StIGNE2lGVD1c9CuguJ+L7/navsE8IcDNndOoCMvYV0qc/exfVbMHkUhvA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.0",
+        "define-property": "1.0.0",
+        "extend-shallow": "2.0.1",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.7",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
+      }
+    },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "minimatch": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+      "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.0.tgz",
+      "integrity": "sha512-dgaCvoh6i1nosAUBKb0l0pfJ78K8+S9fluyIR2YvAeUD/QuMahnFnF3xYty5eYXMjhGSsB0DsW6A0uAZyetoAg==",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "multipipe": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+      "dev": true,
+      "requires": {
+        "duplexer2": "0.0.2"
+      }
+    },
+    "nan": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "dev": true
+    },
+    "nanomatch": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.7.tgz",
+      "integrity": "sha512-/5ldsnyurvEw7wNpxLFgjVvBLMta43niEYOy0CJ4ntcYSbx6bugRUTQeFb4BR/WanEL1o3aQgHuVLHQaB6tOqg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "is-odd": "1.0.0",
+        "kind-of": "5.1.0",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "natives": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
+      "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
+      "dev": true
+    },
+    "node-gyp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+      "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
+      "dev": true,
+      "requires": {
+        "fstream": "1.0.11",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "npmlog": "4.1.2",
+        "osenv": "0.1.4",
+        "request": "2.83.0",
+        "rimraf": "2.6.2",
+        "semver": "5.3.0",
+        "tar": "2.2.1",
+        "which": "1.3.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        }
+      }
+    },
+    "node-sass": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.13.1.tgz",
+      "integrity": "sha1-ckD7v/I5YwS0IjUn7TAgWJwAT8I=",
+      "dev": true,
+      "requires": {
+        "async-foreach": "0.1.3",
+        "chalk": "1.1.3",
+        "cross-spawn": "3.0.1",
+        "gaze": "1.1.2",
+        "get-stdin": "4.0.1",
+        "glob": "7.1.2",
+        "in-publish": "2.0.0",
+        "lodash.assign": "4.2.0",
+        "lodash.clonedeep": "4.5.0",
+        "meow": "3.7.0",
+        "mkdirp": "0.5.1",
+        "nan": "2.8.0",
+        "node-gyp": "3.6.2",
+        "npmlog": "4.1.2",
+        "request": "2.83.0",
+        "sass-graph": "2.2.4"
+      },
+      "dependencies": {
+        "gaze": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+          "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+          "dev": true,
+          "requires": {
+            "globule": "1.2.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "globule": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
+          "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2",
+            "lodash": "4.17.4",
+            "minimatch": "3.0.4"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.1.1"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "4.3.6",
+        "validate-npm-package-license": "3.0.1"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+      "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+      "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "object.defaults": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+      "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+      "dev": true,
+      "requires": {
+        "array-each": "1.0.1",
+        "array-slice": "1.1.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.1"
+      }
+    },
+    "object.map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+      "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+      "dev": true,
+      "requires": {
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.0"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "once": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "orchestrator": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
+      "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "0.1.5",
+        "sequencify": "0.0.7",
+        "stream-consume": "0.1.0"
+      }
+    },
+    "ordered-read-streams": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+      "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
+      "dev": true
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "requires": {
+        "lcid": "1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "osenv": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "parse-filepath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+      "dev": true,
+      "requires": {
+        "is-absolute": "1.0.0",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "dev": true,
+      "requires": {
+        "path-root-regex": "0.1.2"
+      }
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        }
+      }
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "pretty-hrtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      }
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.5.0"
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
+      "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1"
+      }
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
+    "replace-ext": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+      "dev": true
+    },
+    "request": {
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "sass-graph": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+      "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "scss-tokenizer": "0.2.3",
+        "yargs": "7.1.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
+      }
+    },
+    "scss-tokenizer": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+      "dev": true,
+      "requires": {
+        "js-base64": "2.4.3",
+        "source-map": "0.4.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "semver": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+      "dev": true
+    },
+    "sequencify": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+      "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-getter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+      "dev": true,
+      "requires": {
+        "to-object-path": "0.3.0"
+      }
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
+      }
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "snapdragon": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
+      "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
+      "dev": true,
+      "requires": {
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "2.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "dev": true,
+      "requires": {
+        "hoek": "4.2.0"
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+      "dev": true,
+      "requires": {
+        "atob": "2.0.3",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "sparkles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+      "dev": true
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "dev": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "stream-consume": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
+      "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-bom": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+      "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
+      "dev": true,
+      "requires": {
+        "first-chunk-stream": "1.0.0",
+        "is-utf8": "0.2.1"
+      }
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "dev": true,
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
+      }
+    },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "tildify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+      "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "time-stamp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz",
+      "integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "regex-not": "1.0.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "dev": true
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
+      },
+      "dependencies": {
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
+      }
+    },
+    "unique-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
+      "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
+      "dev": true
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        }
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "use": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
+      "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "lazy-cache": "2.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "user-home": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "dev": true
+    },
+    "v8flags": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+      "dev": true,
+      "requires": {
+        "user-home": "1.1.1"
+      }
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    },
+    "vinyl": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+      "dev": true,
+      "requires": {
+        "clone": "1.0.3",
+        "clone-stats": "0.0.1",
+        "replace-ext": "0.0.1"
+      }
+    },
+    "vinyl-fs": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+      "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
+      "dev": true,
+      "requires": {
+        "defaults": "1.0.3",
+        "glob-stream": "3.1.18",
+        "glob-watcher": "0.0.6",
+        "graceful-fs": "3.0.11",
+        "mkdirp": "0.5.1",
+        "strip-bom": "1.0.0",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          }
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+          "dev": true,
+          "requires": {
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
+          }
+        }
+      }
+    },
+    "vinyl-sourcemaps-apply": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      }
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+      "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+      "dev": true,
+      "requires": {
+        "camelcase": "3.0.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "5.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+      "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+      "dev": true,
+      "requires": {
+        "camelcase": "3.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Applications run from the command line would cause a bunch of `Gtk-WARNING`s regarding Theme parsing to appear,
![Screenshot showing `Gtk-WARNING`s on running Gedit.](https://user-images.githubusercontent.com/20952397/35768010-d760ac26-091b-11e8-946c-69218433b970.png)

Further, the files in this repository are a lot older than the ones in the main [Arc Theme repo](https://github.com/horst3180/arc-theme). So to fix this, I've added those files in and edited the colors in `_colors.scss` to suit the color scheme of the theme. I've only done this for the files in directories `common/gtk-3.0/3.20` and `common/gnome-shell/3.18`, however.

I've also edited the README on line 117 to include Red.

P.S., this is my first PR, so any suggestions would be awesome.